### PR TITLE
chore: updated config to include default ingestor config

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -89,3 +89,48 @@ aiAssistant:
       models:
         - endpoint: <your-azure-ai-foundry-endpoint>
           modelName: '<your-model>'
+
+ingestors:
+  # See ./plugins/ai-assistant-backend-module-ingestor-github/config.d.ts for more config options
+  github:
+    owner: <your-github-org-or-username>
+    appId: <your-github-app-id>
+    privateKey: <your-github-private-key>
+    installationId: <your-github-installation-id>
+
+    # optional config to filter what to ingest
+    # filesBatchSize: <number-of-files-to-process-in-batches> # default: 50
+    # baseUrl: <your-github-enterprise-instance-url> # only needed for GitHub Enterprise
+    # fileTypes:
+    #   - '.md'
+    # repositories:
+    #   - name: <repository-name>
+    #     fileTypes:
+    #       - '.json'
+
+  # See ./plugins/ai-assistant-backend-module-ingestor-azure-devops/config.d.ts for more config options
+  azureDevOps:
+    organization: <your-azure-devops-org-name>
+    project: <your-project-name>
+    token: <your-azure-ado-token>
+    resourceTypes:
+      # specify one or both of the following resource types to ingest
+      - 'repository'
+      - 'wiki'
+
+    # optional config to filter what to ingest
+    # fileTypes:
+    #   - '.md'
+    #   - '.json'
+    #   - '.txt'
+    # repositories:
+    #   - name: <repository-name>
+    #     fileTypes:
+    #       - '.json'
+    #       - '.md'
+    #       - '.txt'
+    # filesBatchSize: <number-of-repository-files-to-process-in-batches> # default: 50
+
+    # wikis:
+    #   - name: <wiki-name>
+    # pagesBatchSize: <number-of-wiki-pages-to-process-in-batches> # default: 50


### PR DESCRIPTION
This pull request adds configuration options for integrating GitHub and Azure DevOps ingestors into the `aiAssistant` section of `app-config.yaml`. These changes allow the AI assistant to ingest data from specified GitHub repositories and Azure DevOps resources, with various filtering and batching options.

New ingestor configuration:

**GitHub Ingestor:**
* Added a `github` ingestor configuration, enabling ingestion from GitHub repositories with required parameters such as `owner`, `appId`, `privateKey`, and `installationId`. Optional filters for batch size, file types, and repositories are also provided.

**Azure DevOps Ingestor:**
* Added an `azureDevOps` ingestor configuration, enabling ingestion from Azure DevOps organizations and projects. Supports specifying resource types (`repository`, `wiki`), authentication, and optional filters for file types, repositories, wikis, and batch sizes.