### PR TITLE
fix: add identity + formatting prompts (with defaults) for better control

### DIFF
--- a/.changeset/ready-items-read.md
+++ b/.changeset/ready-items-read.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend': minor
+---
+
+Add split identity and formatting prompts for improved quality and control of responses

--- a/plugins/ai-assistant-backend/src/constants/prompts.ts
+++ b/plugins/ai-assistant-backend/src/constants/prompts.ts
@@ -1,21 +1,30 @@
 export const DEFAULT_SUMMARY_PROMPT =
   'Summarize this conversation in a concise manner. The summary should capture the main points. Return the summary only, without any additional text.';
 
-export const DEFAULT_SYSTEM_PROMPT = `
+export const DEFAULT_IDENTITY_PROMPT = `
 You are a helpful assistant that answers questions based on provided context from various documents. The context may come from sources such as internal wikis, code repositories, technical documentation, or other structured or unstructured data.
+`;
 
-Rules:
+export const DEFAULT_FORMATTING_PROMPT = `
+CRITICAL FORMATTING RULES - MUST ALWAYS FOLLOW:
+1. **ALWAYS use proper markdown formatting in ALL responses**
+2. **NEVER output plain URLs** - ALWAYS convert them to clickable markdown links using [description](url) syntax
+3. **For images, ALWAYS use markdown image syntax**: ![alt text](image-url)
+4. **For all URLs, ALWAYS format as**: [descriptive text](url) - never just paste the raw URL
+5. Use headings (##, ###), bullet points, numbered lists, and **bold**/*italic* text appropriately
+6. Format code with backticks: \`inline code\` or \`\`\`language for code blocks
+7. Structure responses clearly with proper spacing and organization
+`;
+
+export const DEFAULT_SYSTEM_PROMPT = `
+Content Rules:
 1. Always base your answers on the provided context. Do not make up information.
 2. When relevant, cite or reference the source information provided in the context.
-3. Format answers clearly and concisely. Use bullet points for lists when appropriate.
-4. Maintain a professional, friendly, and helpful tone.
-5. Return only the relevant information without any filler or unnecessary details.
-6. If you don't know the answer, admit it and suggest ways to find the information.
-7. Always return a well-structured response using markdown.
-8. **Actively use available tools** to enhance your responses:
-9. Adapt your approach based on the specific tools and capabilities available in the current session
-10. When you have a link to an image, include it in your response using markdown format ![description](image_url).
-11. When you have a link to a document, include it in your response using markdown format [description](document_url).
+3. Maintain a professional, friendly, and helpful tone.
+4. Return only the relevant information without any filler or unnecessary details.
+5. If you don't know the answer, admit it and suggest ways to find the information.
+6. **Actively use available tools** to enhance your responses
+7. Adapt your approach based on the specific tools and capabilities available in the current session
 `;
 
 export const DEFAULT_TOOL_GUIDELINE = `

--- a/plugins/ai-assistant-backend/src/services/chat.ts
+++ b/plugins/ai-assistant-backend/src/services/chat.ts
@@ -91,19 +91,19 @@ export const createChatService = async ({
 }: ChatServiceOptions): Promise<ChatService> => {
   logger.info(`Available models: ${models.map(m => m.id).join(', ')}`);
 
-  const identity =
+  const identityPrompt =
     config.getOptionalString('aiAssistant.prompt.identity') ||
     DEFAULT_IDENTITY_PROMPT;
 
-  const formatting =
+  const formattingPrompt =
     config.getOptionalString('aiAssistant.prompt.formatting') ||
     DEFAULT_FORMATTING_PROMPT;
 
-  const content =
+  const contentPrompt =
     config.getOptionalString('aiAssistant.prompt.content') ||
     DEFAULT_SYSTEM_PROMPT;
 
-  const system = `${identity}\n\n${formatting}\n\n${content}`;
+  const combinedBasePrompt = `${identityPrompt}\n\n${formattingPrompt}\n\n${contentPrompt}`;
 
   const toolGuideline =
     config.getOptionalString('aiAssistant.prompt.toolGuideline') ||
@@ -227,7 +227,7 @@ export const createChatService = async ({
       );
 
       const systemPrompt = await systemPromptTemplate.formatMessages({
-        basePrompt: system,
+        basePrompt: combinedBasePrompt,
         toolGuideline,
         toolList: agentTools
           .map(tool => `- ${tool.name}: ${tool.description}`)

--- a/plugins/ai-assistant-backend/src/services/chat.ts
+++ b/plugins/ai-assistant-backend/src/services/chat.ts
@@ -15,6 +15,8 @@ import {
 } from '@sweetoburrito/backstage-plugin-ai-assistant-common';
 import { SignalsService } from '@backstage/plugin-signals-node';
 import {
+  DEFAULT_FORMATTING_PROMPT,
+  DEFAULT_IDENTITY_PROMPT,
   DEFAULT_SYSTEM_PROMPT,
   DEFAULT_TOOL_GUIDELINE,
 } from '../constants/prompts';
@@ -89,9 +91,19 @@ export const createChatService = async ({
 }: ChatServiceOptions): Promise<ChatService> => {
   logger.info(`Available models: ${models.map(m => m.id).join(', ')}`);
 
-  const system =
-    config.getOptionalString('aiAssistant.prompt.system') ||
+  const identity =
+    config.getOptionalString('aiAssistant.prompt.identity') ||
+    DEFAULT_IDENTITY_PROMPT;
+
+  const formatting =
+    config.getOptionalString('aiAssistant.prompt.formatting') ||
+    DEFAULT_FORMATTING_PROMPT;
+
+  const content =
+    config.getOptionalString('aiAssistant.prompt.content') ||
     DEFAULT_SYSTEM_PROMPT;
+
+  const system = `${identity}\n\n${formatting}\n\n${content}`;
 
   const toolGuideline =
     config.getOptionalString('aiAssistant.prompt.toolGuideline') ||


### PR DESCRIPTION
Link formatting is a bit whack but the links in this are all clickable (where they were not before):

Before:
<img width="1174" height="666" alt="image" src="https://github.com/user-attachments/assets/9278d6ad-588a-4da2-996b-4fe32f6dd00a" />

After:
<img width="1258" height="659" alt="image" src="https://github.com/user-attachments/assets/7870dd38-adc1-462a-9ed7-81dcf6ebd276" />