### PR TITLE
feat: add path filtering

### DIFF
--- a/.changeset/calm-moons-hide.md
+++ b/.changeset/calm-moons-hide.md
@@ -4,4 +4,4 @@
 '@sweetoburrito/backstage-plugin-ai-assistant-common': minor
 ---
 
-add path filtering
+add path filtering tom github and azure ingestors to allow ignoring specific files from ingestion

--- a/.changeset/calm-moons-hide.md
+++ b/.changeset/calm-moons-hide.md
@@ -1,0 +1,7 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend-module-ingestor-azure-devops': minor
+'@sweetoburrito/backstage-plugin-ai-assistant-backend-module-ingestor-github': minor
+'@sweetoburrito/backstage-plugin-ai-assistant-common': minor
+---
+
+add path filtering

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/config.d.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/config.d.ts
@@ -40,12 +40,23 @@ export interface Config {
            * Optional list of file types to ingest for this repository. Overrides the global fileTypes setting for this repository only.
            */
           fileTypes?: string[];
+          /**
+           * Optional list of glob patterns to exclude files and directories from ingestion for this repository.
+           * Overrides the global pathExclusions setting for this repository only.
+           */
+          pathExclusions?: string[];
         }[];
         /**
          * Optional batch size for processing repository files. Defaults to 50 files per batch.
          * Lower values use less memory but may be slower, higher values are faster but use more memory.
          */
         filesBatchSize?: number;
+        /**
+         * Optional list of glob patterns to exclude files and directories from ingestion.
+         * Patterns support glob syntax (e.g., **, *). Defaults to common build artifacts and dependencies if not specified.
+         * Examples: ['node_modules/**', '.git/**', 'dist/**', 'build/**']
+         */
+        pathExclusions?: string[];
 
         /**
          * Optional list of wikis to ingest. If not specified, all wikis in the project will be ingested.

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/constants/default-path-exclusions.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/constants/default-path-exclusions.ts
@@ -1,0 +1,32 @@
+/**
+ * Default path exclusion patterns for common build artifacts and dependencies
+ * used by the Azure DevOps ingestor when no custom exclusions are specified
+ */
+export const DEFAULT_PATH_EXCLUSIONS = [
+  'node_modules/**',
+  '.git/**',
+  '.github/workflows/**',
+  'dist/**',
+  'build/**',
+  'target/**',
+  'vendor/**',
+  '.next/**',
+  '.nuxt/**',
+  'coverage/**',
+  '.nyc_output/**',
+  'out/**',
+  'bin/**',
+  'obj/**',
+  '.vscode/**',
+  '.idea/**',
+  '*.min.js',
+  '*.min.css',
+  '.env',
+  '.env.*',
+  '*.log',
+  'tmp/**',
+  'temp/**',
+  '.cache/**',
+  'bower_components/**',
+  'jspm_packages/**',
+];

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
@@ -11,7 +11,11 @@ import {
 import { AzureDevOpsService } from '../azure-devops';
 import { Config } from '../../../config';
 import { MODULE_ID } from '../../constants/module';
-import { getProgressStats } from '@sweetoburrito/backstage-plugin-ai-assistant-common';
+import {
+  getProgressStats,
+  createPathFilter,
+  validateExclusionPatterns,
+} from '@sweetoburrito/backstage-plugin-ai-assistant-common';
 import { DEFAULT_REPO_FILE_BATCH_SIZE } from '../../constants/default-repo-file-batch-size';
 import {
   GitItem,
@@ -45,6 +49,31 @@ export const createRepositoryIngestor = async ({
     config.getOptionalNumber(
       'aiAssistant.ingestors.azureDevOps.filesBatchSize', // Reuse the same config for consistency
     ) ?? DEFAULT_REPO_FILE_BATCH_SIZE;
+
+  // Get global path exclusion patterns from configuration
+  const globalPathExclusions = config.getOptionalStringArray(
+    'aiAssistant.ingestors.azureDevOps.pathExclusions',
+  );
+
+  // Validate exclusion patterns if provided
+  if (globalPathExclusions) {
+    const validation = validateExclusionPatterns(globalPathExclusions);
+    if (!validation.isValid) {
+      logger.error(
+        `Invalid path exclusion patterns in Azure DevOps ingestor configuration: ${validation.errors.join(
+          ', ',
+        )}`,
+      );
+      throw new Error(
+        `Invalid path exclusion patterns: ${validation.errors.join(', ')}`,
+      );
+    }
+    if (validation.warnings.length > 0) {
+      logger.warn(
+        `Path exclusion pattern warnings: ${validation.warnings.join(', ')}`,
+      );
+    }
+  }
 
   /**
    * Ingest Azure DevOps repository items in batches
@@ -187,17 +216,62 @@ export const createRepositoryIngestor = async ({
           r => r.name.toLowerCase() === repo.name!.toLowerCase(),
         )?.fileTypes ?? fileTypes;
 
+      // Determine the path exclusions to use for this repository or use global default
+      const repositoryPathExclusions =
+        repositoriesFilter?.find(
+          r => r.name.toLowerCase() === repo.name!.toLowerCase(),
+        )?.pathExclusions ?? globalPathExclusions;
+
       logger.info(
         `Processing file types for repository ${
           repo.name
         }: [${repositoryFileTypesFilter.join(', ')}]`,
       );
 
+      if (repositoryPathExclusions) {
+        logger.info(
+          `Using path exclusions for repository ${
+            repo.name
+          }: [${repositoryPathExclusions.join(', ')}]`,
+        );
+      }
+
       // Get the items to be ingested from the repository based on the file types filter
-      const items = await azureDevOpsService.getRepoItems(
+      let items = await azureDevOpsService.getRepoItems(
         repo.id!,
         repositoryFileTypesFilter,
       );
+
+      // Apply path exclusion filtering if configured
+      if (repositoryPathExclusions) {
+        const pathFilter = createPathFilter({
+          exclusionPatterns: repositoryPathExclusions,
+        });
+        
+        const originalItemCount = items.length;
+        
+        // Log excluded items for debugging
+        const excludedItems = items.filter(item => 
+          item.path && pathFilter.shouldExcludePath(item.path)
+        );
+        
+        if (excludedItems.length > 0) {
+          logger.debug(
+            `Items excluded from repository ${repo.name}: ${excludedItems
+              .map(i => i.path)
+              .join(', ')}`,
+          );
+        }
+        
+        items = pathFilter.filterFiles(items);
+        const filteredItemCount = originalItemCount - items.length;
+        
+        if (filteredItemCount > 0) {
+          logger.info(
+            `Filtered out ${filteredItemCount} items from repository ${repo.name} based on path exclusion patterns`,
+          );
+        }
+      }
 
       if (items.length === 0) {
         logger.warn(

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
@@ -247,14 +247,14 @@ export const createRepositoryIngestor = async ({
         const pathFilter = createPathFilter({
           exclusionPatterns: repositoryPathExclusions,
         });
-        
+
         const originalItemCount = items.length;
-        
+
         // Log excluded items for debugging
-        const excludedItems = items.filter(item => 
-          item.path && pathFilter.shouldExcludePath(item.path)
+        const excludedItems = items.filter(
+          item => item.path && pathFilter.shouldExcludePath(item.path),
         );
-        
+
         if (excludedItems.length > 0) {
           logger.debug(
             `Items excluded from repository ${repo.name}: ${excludedItems
@@ -262,10 +262,10 @@ export const createRepositoryIngestor = async ({
               .join(', ')}`,
           );
         }
-        
+
         items = pathFilter.filterFiles(items);
         const filteredItemCount = originalItemCount - items.length;
-        
+
         if (filteredItemCount > 0) {
           logger.info(
             `Filtered out ${filteredItemCount} items from repository ${repo.name} based on path exclusion patterns`,

--- a/plugins/ai-assistant-backend-module-ingestor-github/config.d.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-github/config.d.ts
@@ -38,6 +38,12 @@ export interface Config {
          */
         filesBatchSize?: number;
         /**
+         * Optional list of glob patterns to exclude files and directories from ingestion.
+         * Patterns support glob syntax (e.g., **, *). Defaults to common build artifacts and dependencies if not specified.
+         * Examples: ['node_modules/**', '.git/**', 'dist/**', 'build/**']
+         */
+        pathExclusions?: string[];
+        /**
          * Optional list of repositories to ingest. If not specified, all repositories for the owner will be ingested.
          */
         repositories?: {
@@ -49,6 +55,11 @@ export interface Config {
            * Optional list of file types to ingest for this repository. Overrides the global fileTypes setting for this repository only.
            */
           fileTypes?: string[];
+          /**
+           * Optional list of glob patterns to exclude files and directories from ingestion for this repository.
+           * Overrides the global pathExclusions setting for this repository only.
+           */
+          pathExclusions?: string[];
         }[];
       };
     };

--- a/plugins/ai-assistant-backend-module-ingestor-github/src/constants/default-path-exclusions.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-github/src/constants/default-path-exclusions.ts
@@ -1,0 +1,32 @@
+/**
+ * Default path exclusion patterns for common build artifacts and dependencies
+ * used by the GitHub ingestor when no custom exclusions are specified
+ */
+export const DEFAULT_PATH_EXCLUSIONS = [
+  'node_modules/**',
+  '.git/**',
+  '.github/workflows/**',
+  'dist/**',
+  'build/**',
+  'target/**',
+  'vendor/**',
+  '.next/**',
+  '.nuxt/**',
+  'coverage/**',
+  '.nyc_output/**',
+  'out/**',
+  'bin/**',
+  'obj/**',
+  '.vscode/**',
+  '.idea/**',
+  '*.min.js',
+  '*.min.css',
+  '.env',
+  '.env.*',
+  '*.log',
+  'tmp/**',
+  'temp/**',
+  '.cache/**',
+  'bower_components/**',
+  'jspm_packages/**',
+];

--- a/plugins/ai-assistant-backend-module-ingestor-github/src/services/ingestor.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-github/src/services/ingestor.ts
@@ -10,7 +10,11 @@ import {
 } from '@sweetoburrito/backstage-plugin-ai-assistant-node';
 import { MODULE_ID } from '../constants/module';
 import { Config } from '../../config';
-import { getProgressStats } from '@sweetoburrito/backstage-plugin-ai-assistant-common';
+import {
+  getProgressStats,
+  createPathFilter,
+  validateExclusionPatterns,
+} from '@sweetoburrito/backstage-plugin-ai-assistant-common';
 import { DEFAULT_FILE_BATCH_SIZE } from '../constants/default-file-batch-size';
 
 export const createGitHubIngestor = async ({
@@ -36,6 +40,31 @@ export const createGitHubIngestor = async ({
   const filesBatchSize =
     config.getOptionalNumber('aiAssistant.ingestors.github.filesBatchSize') ??
     DEFAULT_FILE_BATCH_SIZE;
+
+  // Get global path exclusion patterns from configuration
+  const globalPathExclusions = config.getOptionalStringArray(
+    'aiAssistant.ingestors.github.pathExclusions',
+  );
+
+  // Validate exclusion patterns if provided
+  if (globalPathExclusions) {
+    const validation = validateExclusionPatterns(globalPathExclusions);
+    if (!validation.isValid) {
+      logger.error(
+        `Invalid path exclusion patterns in GitHub ingestor configuration: ${validation.errors.join(
+          ', ',
+        )}`,
+      );
+      throw new Error(
+        `Invalid path exclusion patterns: ${validation.errors.join(', ')}`,
+      );
+    }
+    if (validation.warnings.length > 0) {
+      logger.warn(
+        `Path exclusion pattern warnings: ${validation.warnings.join(', ')}`,
+      );
+    }
+  }
 
   // Create GitHub service
   const githubService = await createGitHubService({ config, logger });
@@ -208,17 +237,62 @@ export const createGitHubIngestor = async ({
           r => r.name.toLowerCase() === repo.name.toLowerCase(),
         )?.fileTypes ?? fileTypes;
 
+      // Determine the path exclusions to use for this repository or use global default
+      const repositoryPathExclusions =
+        repositoriesFilter?.find(
+          r => r.name.toLowerCase() === repo.name.toLowerCase(),
+        )?.pathExclusions ?? globalPathExclusions;
+
       logger.info(
         `Processing file types for repository ${
           repo.name
         }: [${repositoryFileTypesFilter.join(', ')}]`,
       );
 
+      if (repositoryPathExclusions) {
+        logger.info(
+          `Using path exclusions for repository ${
+            repo.name
+          }: [${repositoryPathExclusions.join(', ')}]`,
+        );
+      }
+
       // Get the files to be ingested from the repository based on the file types filter
-      const files = await githubService.getRepoFiles(
+      let files = await githubService.getRepoFiles(
         repo.name,
         repositoryFileTypesFilter,
       );
+
+      // Apply path exclusion filtering if configured
+      if (repositoryPathExclusions) {
+        const pathFilter = createPathFilter({
+          exclusionPatterns: repositoryPathExclusions,
+        });
+        
+        const originalFileCount = files.length;
+        
+        // Log excluded files for debugging
+        const excludedFiles = files.filter(file => 
+          file.path && pathFilter.shouldExcludePath(file.path)
+        );
+        
+        if (excludedFiles.length > 0) {
+          logger.debug(
+            `Files excluded from repository ${repo.name}: ${excludedFiles
+              .map(f => f.path)
+              .join(', ')}`,
+          );
+        }
+        
+        files = pathFilter.filterFiles(files);
+        const filteredFileCount = originalFileCount - files.length;
+        
+        if (filteredFileCount > 0) {
+          logger.info(
+            `Filtered out ${filteredFileCount} files from repository ${repo.name} based on path exclusion patterns`,
+          );
+        }
+      }
 
       if (files.length === 0) {
         logger.warn(

--- a/plugins/ai-assistant-backend-module-ingestor-github/src/services/ingestor.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-github/src/services/ingestor.ts
@@ -268,14 +268,14 @@ export const createGitHubIngestor = async ({
         const pathFilter = createPathFilter({
           exclusionPatterns: repositoryPathExclusions,
         });
-        
+
         const originalFileCount = files.length;
-        
+
         // Log excluded files for debugging
-        const excludedFiles = files.filter(file => 
-          file.path && pathFilter.shouldExcludePath(file.path)
+        const excludedFiles = files.filter(
+          file => file.path && pathFilter.shouldExcludePath(file.path),
         );
-        
+
         if (excludedFiles.length > 0) {
           logger.debug(
             `Files excluded from repository ${repo.name}: ${excludedFiles
@@ -283,10 +283,10 @@ export const createGitHubIngestor = async ({
               .join(', ')}`,
           );
         }
-        
+
         files = pathFilter.filterFiles(files);
         const filteredFileCount = originalFileCount - files.length;
-        
+
         if (filteredFileCount > 0) {
           logger.info(
             `Filtered out ${filteredFileCount} files from repository ${repo.name} based on path exclusion patterns`,

--- a/plugins/ai-assistant-common/package.json
+++ b/plugins/ai-assistant-common/package.json
@@ -37,6 +37,7 @@
     "dist"
   ],
   "dependencies": {
-    "@langchain/mcp-adapters": "^1.0.0"
+    "@langchain/mcp-adapters": "^1.0.0",
+    "minimatch": "^10.0.1"
   }
 }

--- a/plugins/ai-assistant-common/src/utils/index.ts
+++ b/plugins/ai-assistant-common/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './get-progress-stats';
+export * from './path-filter';

--- a/plugins/ai-assistant-common/src/utils/path-filter.ts
+++ b/plugins/ai-assistant-common/src/utils/path-filter.ts
@@ -1,43 +1,11 @@
 import { minimatch } from 'minimatch';
 
 /**
- * Default path exclusion patterns for common build artifacts and dependencies
- */
-export const DEFAULT_PATH_EXCLUSIONS = [
-  'node_modules/**',
-  '.git/**',
-  '.github/workflows/**',
-  'dist/**',
-  'build/**',
-  'target/**',
-  'vendor/**',
-  '.next/**',
-  '.nuxt/**',
-  'coverage/**',
-  '.nyc_output/**',
-  'out/**',
-  'bin/**',
-  'obj/**',
-  '.vscode/**',
-  '.idea/**',
-  '*.min.js',
-  '*.min.css',
-  '.env',
-  '.env.*',
-  '*.log',
-  'tmp/**',
-  'temp/**',
-  '.cache/**',
-  'bower_components/**',
-  'jspm_packages/**',
-];
-
-/**
  * Options for path filtering
  */
 export interface PathFilterOptions {
   /** Array of glob patterns to exclude from processing */
-  exclusionPatterns?: string[];
+  exclusionPatterns: string[];
   /** Whether to use case-insensitive matching (default: true) */
   caseInsensitive?: boolean;
 }
@@ -46,11 +14,8 @@ export interface PathFilterOptions {
  * Creates a path filter function that can determine if a file path should be excluded
  * based on configured glob patterns
  */
-export function createPathFilter(options: PathFilterOptions = {}) {
-  const {
-    exclusionPatterns = DEFAULT_PATH_EXCLUSIONS,
-    caseInsensitive = true,
-  } = options;
+export function createPathFilter(options: PathFilterOptions) {
+  const { exclusionPatterns, caseInsensitive = true } = options;
 
   /**
    * Tests if a file path should be excluded based on configured patterns

--- a/plugins/ai-assistant-common/src/utils/path-filter.ts
+++ b/plugins/ai-assistant-common/src/utils/path-filter.ts
@@ -1,0 +1,143 @@
+import { minimatch } from 'minimatch';
+
+/**
+ * Default path exclusion patterns for common build artifacts and dependencies
+ */
+export const DEFAULT_PATH_EXCLUSIONS = [
+  'node_modules/**',
+  '.git/**',
+  '.github/workflows/**',
+  'dist/**',
+  'build/**',
+  'target/**',
+  'vendor/**',
+  '.next/**',
+  '.nuxt/**',
+  'coverage/**',
+  '.nyc_output/**',
+  'out/**',
+  'bin/**',
+  'obj/**',
+  '.vscode/**',
+  '.idea/**',
+  '*.min.js',
+  '*.min.css',
+  '.env',
+  '.env.*',
+  '*.log',
+  'tmp/**',
+  'temp/**',
+  '.cache/**',
+  'bower_components/**',
+  'jspm_packages/**',
+];
+
+/**
+ * Options for path filtering
+ */
+export interface PathFilterOptions {
+  /** Array of glob patterns to exclude from processing */
+  exclusionPatterns?: string[];
+  /** Whether to use case-insensitive matching (default: true) */
+  caseInsensitive?: boolean;
+}
+
+/**
+ * Creates a path filter function that can determine if a file path should be excluded
+ * based on configured glob patterns
+ */
+export function createPathFilter(options: PathFilterOptions = {}) {
+  const {
+    exclusionPatterns = DEFAULT_PATH_EXCLUSIONS,
+    caseInsensitive = true,
+  } = options;
+
+  /**
+   * Tests if a file path should be excluded based on configured patterns
+   * @param filePath - The file path to test
+   * @returns true if the path should be excluded, false otherwise
+   */
+  const shouldExcludePath = (filePath: string): boolean => {
+    if (!filePath) return false;
+
+    // Normalize path separators to forward slashes for consistent matching
+    const normalizedPath = filePath.replace(/\\/g, '/');
+
+    return exclusionPatterns.some(pattern =>
+      minimatch(normalizedPath, pattern, {
+        nocase: caseInsensitive,
+        matchBase: true,
+      }),
+    );
+  };
+
+  /**
+   * Filter an array of file paths, removing those that match exclusion patterns
+   * @param filePaths - Array of file paths to filter
+   * @returns Array of file paths that should not be excluded
+   */
+  const filterPaths = (filePaths: string[]): string[] => {
+    return filePaths.filter(path => !shouldExcludePath(path));
+  };
+
+  /**
+   * Filter an array of file objects with path property, removing those that match exclusion patterns
+   * @param files - Array of file objects with path property
+   * @returns Array of file objects that should not be excluded
+   */
+  const filterFiles = <T extends { path?: string }>(files: T[]): T[] => {
+    return files.filter(file => !file.path || !shouldExcludePath(file.path));
+  };
+
+  return {
+    shouldExcludePath,
+    filterPaths,
+    filterFiles,
+    exclusionPatterns,
+  };
+}
+
+/**
+ * Validates an array of glob patterns for common issues
+ * @param patterns - Array of glob patterns to validate
+ * @returns Object with validation results
+ */
+export function validateExclusionPatterns(patterns: string[]): {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+} {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  for (const pattern of patterns) {
+    if (!pattern || typeof pattern !== 'string') {
+      errors.push(`Invalid pattern: ${pattern} - must be a non-empty string`);
+      continue;
+    }
+
+    if (pattern.trim() !== pattern) {
+      warnings.push(`Pattern has leading/trailing whitespace: "${pattern}"`);
+    }
+
+    // Check for potentially problematic patterns
+    if (pattern === '**' || pattern === '*') {
+      warnings.push(
+        `Very broad pattern "${pattern}" may exclude too many files`,
+      );
+    }
+
+    // Check for Windows-style backslashes
+    if (pattern.includes('\\')) {
+      warnings.push(
+        `Pattern "${pattern}" contains backslashes - consider using forward slashes for cross-platform compatibility`,
+      );
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5375,6 +5375,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/balanced-match@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@isaacs/balanced-match@npm:4.0.1"
+  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
+  languageName: node
+  linkType: hard
+
+"@isaacs/brace-expansion@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+  dependencies:
+    "@isaacs/balanced-match": "npm:^4.0.1"
+  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -11437,6 +11453,7 @@ __metadata:
   dependencies:
     "@backstage/cli": "backstage:^"
     "@langchain/mcp-adapters": "npm:^1.0.0"
+    minimatch: "npm:^10.0.1"
   languageName: unknown
   linkType: soft
 
@@ -23257,6 +23274,15 @@ __metadata:
   version: 1.0.1
   resolution: "minimalistic-crypto-utils@npm:1.0.1"
   checksum: 10c0/790ecec8c5c73973a4fbf2c663d911033e8494d5fb0960a4500634766ab05d6107d20af896ca2132e7031741f19888154d44b2408ada0852446705441383e9f8
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.1":
+  version: 10.1.1
+  resolution: "minimatch@npm:10.1.1"
+  dependencies:
+    "@isaacs/brace-expansion": "npm:^5.0.0"
+  checksum: 10c0/c85d44821c71973d636091fddbfbffe62370f5ee3caf0241c5b60c18cd289e916200acb2361b7e987558cd06896d153e25d505db9fc1e43e6b4b6752e2702902
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces configurable path exclusion filtering to both the Azure DevOps and GitHub repository ingestors, allowing users to specify glob patterns to exclude files or directories from ingestion. It also adds validation and logging for exclusion patterns, and centralizes path filtering logic in a new utility. The changes improve flexibility, debugging, and maintainability of the ingestion process.