### PR TITLE
fix: update document batch saving to prevent large docs causing hangups

### DIFF
--- a/.changeset/old-berries-shake.md
+++ b/.changeset/old-berries-shake.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend': patch
+---
+
+fixed an issue where when ingesting large documents the servie would hangup until complted

--- a/.github/workflows/snapshot-release.yaml
+++ b/.github/workflows/snapshot-release.yaml
@@ -17,6 +17,7 @@ jobs:
   snapshot-release:
     name: Publish Snapshot
     runs-on: ubuntu-latest
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/checkout@v4
 

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -39,7 +39,7 @@ auth:
 # see https://backstage.io/docs/permissions/getting-started for more on the permission framework
 permission:
   # setting this to `false` will disable permissions
-  enabled: true
+  enabled: false
 
 catalog:
   orphanStrategy: delete
@@ -74,6 +74,10 @@ aiAssistant:
         days: 1
       timeout:
         hours: 1
+    chunking:
+      chunkSize: 1000
+      chunkOverlap: 100
+      maxChunkProcessingSize: 100
   embeddings:
     ollama:
       model: '<your-model>'

--- a/plugins/ai-assistant-backend/config.d.ts
+++ b/plugins/ai-assistant-backend/config.d.ts
@@ -28,6 +28,22 @@ export interface Config {
     };
     ingestion?: {
       schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
+      chunking?: {
+        /**
+         * The size of text chunks to split documents into during ingestion
+         */
+        chunkSize?: number;
+
+        /**
+         * The amount of overlap between text chunks during ingestion
+         */
+        chunkOverlap?: number;
+
+        /**
+         * The maximum number of chunks to process in a single batch when ingesting documents
+         */
+        maxChunkProcessingSize?: number;
+      };
     };
     mcp: {
       /**


### PR DESCRIPTION
This pull request introduces configurable chunking and batch processing for document ingestion in the AI Assistant backend, addressing issues with service hangs when processing large documents. It also includes configuration changes to disable permissions and adds a safeguard in the snapshot release workflow.

**Backend ingestion improvements:**

* Made chunk size, chunk overlap, and maximum chunk processing size configurable via the `app-config.yaml` file, allowing for better handling of large documents during ingestion (`plugins/ai-assistant-backend/src/services/ingestor.ts`, `app-config.yaml`). [[1]](diffhunk://#diff-19daf4d2eaa5daba45ae02055b75ea4976e3efe23f72e3804dcf11851c8d070cR24-R27) [[2]](diffhunk://#diff-19daf4d2eaa5daba45ae02055b75ea4976e3efe23f72e3804dcf11851c8d070cR41-R53) [[3]](diffhunk://#diff-19daf4d2eaa5daba45ae02055b75ea4976e3efe23f72e3804dcf11851c8d070cL60-R81) [[4]](diffhunk://#diff-19daf4d2eaa5daba45ae02055b75ea4976e3efe23f72e3804dcf11851c8d070cL76-R119) [[5]](diffhunk://#diff-ec52f22d476ccc33271d11c4f08a68369614378aa0cb9aa5aba2f08943cd68dfR77-R80)
* Changed ingestion logic to process and add document chunks to the vector store in batches, preventing service hangups with large documents (`plugins/ai-assistant-backend/src/services/ingestor.ts`).
* Added a patch changelog entry describing the fix for hangs during large document ingestion (`.changeset/old-berries-shake.md`).

**Configuration and workflow changes:**

* Disabled the permissions framework by default in `app-config.yaml` (`app-config.yaml`).
* Updated the snapshot release GitHub workflow to not run on changeset release branches (`.github/workflows/snapshot-release.yaml`).