### PR TITLE
feat: add core tools system

### DIFF
--- a/.changeset/deep-paws-serve.md
+++ b/.changeset/deep-paws-serve.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-common': minor
+---
+
+include description in EnabledTool type definition and remove user tool type

--- a/.changeset/legal-things-wait.md
+++ b/.changeset/legal-things-wait.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant': minor
+---
+
+refactor tool fetching to set core tools as default enabled for first time users and ensure core tools are always enabled

--- a/.changeset/shaggy-onions-ring.md
+++ b/.changeset/shaggy-onions-ring.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend': minor
+---
+
+refactor tools registration and add non disableable core tools system

--- a/plugins/ai-assistant-backend/src/plugin.ts
+++ b/plugins/ai-assistant-backend/src/plugin.ts
@@ -134,7 +134,8 @@ export const aiAssistantPlugin = createBackendPlugin({
 
         const searchKnowledgeTool = createSearchKnowledgeTool({ vectorStore });
 
-        tool.registerTools([...tools, searchKnowledgeTool]);
+        tool.registerTools(tools);
+        tool.registerCoreTools([searchKnowledgeTool]);
         callback.registerCallbacks(callbacks);
         model.registerModels(models);
 

--- a/plugins/ai-assistant-backend/src/services/router/chat.ts
+++ b/plugins/ai-assistant-backend/src/services/router/chat.ts
@@ -8,21 +8,19 @@ import {
   HttpAuthService,
   UserInfoService,
 } from '@backstage/backend-plugin-api';
-import { ToolsService } from '../tools';
 import { ConversationService } from '../conversation';
 
 export type ChatRouterOptions = {
   chat: ChatService;
   httpAuth: HttpAuthService;
   userInfo: UserInfoService;
-  tool: ToolsService;
   conversation: ConversationService;
 };
 
 export async function createChatRouter(
   options: ChatRouterOptions,
 ): Promise<express.Router> {
-  const { chat, httpAuth, userInfo, tool, conversation } = options;
+  const { chat, httpAuth, userInfo, conversation } = options;
 
   const router = Router();
 
@@ -84,14 +82,6 @@ export async function createChatRouter(
     });
 
     res.json({ conversations });
-  });
-
-  router.get('/tools', async (req, res) => {
-    const credentials = await httpAuth.credentials(req);
-
-    const tools = await tool.getAvailableUserTools({ credentials });
-
-    res.json({ tools });
   });
 
   router.get('/:id', validation(chatSchema, 'params'), async (req, res) => {

--- a/plugins/ai-assistant-backend/src/services/router/index.ts
+++ b/plugins/ai-assistant-backend/src/services/router/index.ts
@@ -10,12 +10,14 @@ import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { SummaryRouterOptions, createSummaryRouter } from './summary';
 import { createSettingsRouter, SettingsRouterOptions } from './settings';
 import { createAgentRouter, AgentRouterOptions } from './agent';
+import { createToolRouter, ToolRouterOptions } from './tools';
 
 export type RouterOptions = ChatRouterOptions &
   SummaryRouterOptions &
   ModelRouterOptions &
   SettingsRouterOptions &
-  AgentRouterOptions & {
+  AgentRouterOptions &
+  ToolRouterOptions & {
     config: RootConfigService;
     logger: LoggerService;
   };
@@ -31,6 +33,7 @@ export async function createRouter(
   router.use('/summary', await createSummaryRouter(options));
   router.use('/settings', await createSettingsRouter(options));
   router.use('/agent', await createAgentRouter(options));
+  router.use('/tools', await createToolRouter(options));
 
   const middleware = MiddlewareFactory.create(options);
 

--- a/plugins/ai-assistant-backend/src/services/router/tools.ts
+++ b/plugins/ai-assistant-backend/src/services/router/tools.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import Router from 'express-promise-router';
+import { HttpAuthService } from '@backstage/backend-plugin-api';
+import { ToolsService } from '../tools';
+
+export type ToolRouterOptions = {
+  httpAuth: HttpAuthService;
+  tool: ToolsService;
+};
+
+export async function createToolRouter(
+  options: ToolRouterOptions,
+): Promise<express.Router> {
+  const { httpAuth, tool } = options;
+  const router = Router();
+
+  router.get('/', async (req, res) => {
+    const credentials = await httpAuth.credentials(req);
+
+    const tools = await tool.getAvailableUserTools({ credentials });
+
+    res.json({ tools });
+  });
+
+  return router;
+}

--- a/plugins/ai-assistant-backend/src/services/tools.ts
+++ b/plugins/ai-assistant-backend/src/services/tools.ts
@@ -77,7 +77,9 @@ const createToolsService = async ({
 
     const userTools = tools.concat(mcpTools);
 
-    const allTools: Tool[] = userTools.filter(filter).concat(coreTools.filter(filter));
+    const allTools: Tool[] = userTools
+      .filter(filter)
+      .concat(coreTools.filter(filter));
     return allTools.map(t => new DynamicStructuredTool(t));
   };
 

--- a/plugins/ai-assistant-backend/src/services/tools.ts
+++ b/plugins/ai-assistant-backend/src/services/tools.ts
@@ -77,8 +77,8 @@ const createToolsService = async ({
 
     const userTools = tools.concat(mcpTools);
 
-    const allTools: Tool[] = userTools.filter(filter).concat(coreTools);
-    return allTools.filter(filter).map(t => new DynamicStructuredTool(t));
+    const allTools: Tool[] = userTools.filter(filter).concat(coreTools.filter(filter));
+    return allTools.map(t => new DynamicStructuredTool(t));
   };
 
   return {

--- a/plugins/ai-assistant-common/src/types/tool.ts
+++ b/plugins/ai-assistant-common/src/types/tool.ts
@@ -12,6 +12,4 @@ export type Tool<T extends ZodType<any, any, any> = ZodType<any, any, any>> = {
   }>;
 };
 
-export type UserTool = Pick<Tool, 'name' | 'provider' | 'description'>;
-
-export type EnabledTool = Pick<Tool, 'name' | 'provider'>;
+export type EnabledTool = Pick<Tool, 'name' | 'provider' | 'description'>;

--- a/plugins/ai-assistant/src/hooks/use-chat-settings.ts
+++ b/plugins/ai-assistant/src/hooks/use-chat-settings.ts
@@ -105,15 +105,13 @@ export const useChatSettings = () => {
     // Persist to backend
     await fetchApi.fetch(`${baseUrl}/settings`, {
       method: 'PATCH',
-      body: JSON.stringify({ type: 'user-tools', settings: { tools: coreTools } }),
+      body: JSON.stringify({
+        type: 'user-tools',
+        settings: { tools: coreTools },
+      }),
       headers: { 'Content-Type': 'application/json' },
     });
-  }, [
-    discoveryApi,
-    fetchApi,
-    setToolsEnabledState,
-    getAvailableTools,
-  ]);
+  }, [discoveryApi, fetchApi, setToolsEnabledState, getAvailableTools]);
 
   useEffect(() => {
     fetchUserEnabledTools();

--- a/plugins/ai-assistant/src/hooks/use-chat-settings.ts
+++ b/plugins/ai-assistant/src/hooks/use-chat-settings.ts
@@ -101,13 +101,18 @@ export const useChatSettings = () => {
 
     const coreTools = availableTools.filter(tool => tool.provider === 'core');
 
-    setToolsEnabled(coreTools);
+    setToolsEnabledState(coreTools);
+    // Persist to backend
+    await fetchApi.fetch(`${baseUrl}/settings`, {
+      method: 'PATCH',
+      body: JSON.stringify({ type: 'user-tools', settings: { tools: coreTools } }),
+      headers: { 'Content-Type': 'application/json' },
+    });
   }, [
     discoveryApi,
     fetchApi,
     setToolsEnabledState,
     getAvailableTools,
-    setToolsEnabled,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This pull request refactors the AI Assistant plugin's tool management system to introduce a new concept of "core tools" that are always enabled and cannot be disabled by users. It also simplifies the types used for enabled tools, ensures core tools are set as defaults for first-time users, and moves tool fetching to a dedicated backend route for better separation of concerns.

**Core tools system and tool registration:**
* Refactored backend tool registration to support non-disableable core tools, separating core tool registration from user tool registration in `plugins/ai-assistant-backend/src/services/tools.ts` and `plugins/ai-assistant-backend/src/plugin.ts`. [[1]](diffhunk://#diff-1e06b5fc11b8733d1a72a9341c304933f9ca85b1140730021b0c2aea5e0be18bR1-R5) [[2]](diffhunk://#diff-a552de46607e409f8d7e3fe61c627d7c7b512ce08ce978ba6753b8ad742b4151L137-R138) [[3]](diffhunk://#diff-a2f6d2d432ed3dbc41f448901526fd05385685dec2009eb72519313b832f305cR38-R57)
* Updated the logic for fetching available tools to always include core tools and ensure they are enabled by default for first-time users in `plugins/ai-assistant/src/hooks/use-chat-settings.ts`. [[1]](diffhunk://#diff-94c99fb539d1f78224479cd3c948f268ea5622678105c3cbd0683407ecde2e89R1-R5) [[2]](diffhunk://#diff-a3b6e5ec308942cfd5b0d474bfb540a09c6244ade69c4a46f87b7e850d970f12L83-R111)

**API and routing improvements:**
* Moved the `/tools` endpoint to its own router (`plugins/ai-assistant-backend/src/services/router/tools.ts`) and updated routing setup to use this new router, improving separation of concerns. [[1]](diffhunk://#diff-6fc45ca3d30d7a97acbd1df59ed130bcd7213f646376441c6750e1170dd433bdR1-R26) [[2]](diffhunk://#diff-9e9726bda99c3acce33dd3366e95da1af68421791ed9ba3bd75ee8c65fa25318R13-R20) [[3]](diffhunk://#diff-9e9726bda99c3acce33dd3366e95da1af68421791ed9ba3bd75ee8c65fa25318R36)
* Removed the old `/chat/tools` endpoint from the chat router to avoid duplication and confusion.

**Type and frontend updates:**
* Simplified the `EnabledTool` type to always include the `description` field and removed the obsolete `UserTool` type in `plugins/ai-assistant-common/src/types/tool.ts`, updating all frontend usages accordingly. [[1]](diffhunk://#diff-8323ae377380dd9fc5eb0f807f076e31c74186668ea234dea77495e8a8d44684R1-R5) [[2]](diffhunk://#diff-c394820e715e327a4bd24862ae2d8981c3d5b6a73bd2c918a8c6861d6cb59702L15-R15) [[3]](diffhunk://#diff-a133ee05a863f1824a60c131c0e4bd05b8d024e419b3878e42161733d9c73f98L3-R4) [[4]](diffhunk://#diff-a133ee05a863f1824a60c131c0e4bd05b8d024e419b3878e42161733d9c73f98L111-R95) [[5]](diffhunk://#diff-a133ee05a863f1824a60c131c0e4bd05b8d024e419b3878e42161733d9c73f98L134-R119)
* Updated the frontend settings modal and hooks to display and handle core tools correctly, disabling controls for core tools so users cannot deselect them. [[1]](diffhunk://#diff-a133ee05a863f1824a60c131c0e4bd05b8d024e419b3878e42161733d9c73f98L67-R67) [[2]](diffhunk://#diff-a133ee05a863f1824a60c131c0e4bd05b8d024e419b3878e42161733d9c73f98R167) [[3]](diffhunk://#diff-a133ee05a863f1824a60c131c0e4bd05b8d024e419b3878e42161733d9c73f98R190)

These changes improve the reliability and clarity of tool management in the AI Assistant plugin, ensuring essential tools are always available and simplifying user experience.