### PR TITLE
feat: ado resource filtering using regex

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -140,15 +140,36 @@ aiAssistant:
       #   - '.json'
       #   - '.txt'
       # repositories:
-      #   - name: <repository-name>
-      #     fileTypes:
-      #       - '.json'
-      #       - '.md'
-      #       - '.txt'
+      #   include:
+      #     # Exact name matching (case-sensitive)
+      #     - name: backend-api
+      #       fileTypes:
+      #         - '.json'
+      #         - '.md'
+      #     # Regex pattern matching (automatically treated as regex)
+      #     - name: '^backend-.*'         # All repos starting with 'backend-'
+      #     - name: '.*-service$'         # All repos ending with '-service'
+      #   exclude:
+      #     # Exclude by exact name
+      #     - name: test-repo
+      #     # Exclude by regex pattern
+      #     - name: '^temp-.*'            # Exclude repos starting with 'temp-'
+      #     - name: '.*-archived$'        # Exclude repos ending with '-archived'
       # filesBatchSize: <number-of-repository-files-to-process-in-batches> # default: 50
 
       # wikis:
-      #   - name: <wiki-name>
+      #   include:
+      #     # Exact name matching (case-sensitive)
+      #     - name: production-wiki
+      #     # Regex pattern matching (automatically treated as regex)
+      #     - name: '^prod-.*'            # All wikis starting with 'prod-'
+      #     - name: '.*-docs$'            # All wikis ending with '-docs'
+      #   exclude:
+      #     # Exclude by exact name
+      #     - name: draft-wiki
+      #     # Exclude by regex pattern
+      #     - name: '^test-.*'            # Exclude wikis starting with 'test-'
+      #     - name: '.*-temp$'            # Exclude wikis ending with '-temp'
       # pagesBatchSize: <number-of-wiki-pages-to-process-in-batches> # default: 50
 
   callbacks:

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/config.d.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/config.d.ts
@@ -29,23 +29,55 @@ export interface Config {
          */
         fileTypes?: string[];
         /**
-         * Optional list of repositories to ingest. If not specified, all repositories in the project will be ingested.
+         * Optional configuration for filtering repositories to ingest.
+         * If not specified, all repositories in the project will be ingested.
+         * Supports both exact name matching and regex patterns for flexible filtering.
          */
         repositories?: {
           /**
-           * The name of the repository to ingest
+           * List of repositories to include for ingestion.
+           * If specified, only repositories matching these criteria will be ingested (unless excluded).
            */
-          name: string;
+          include?: {
+            /**
+             * Repository name or regular expression pattern.
+             * All values are treated as regex patterns for matching:
+             * - Plain strings (e.g., 'my-repo') match exactly that string (case-sensitive)
+             * - Regex patterns (e.g., '^backend-.*', '.*-service$') match using regex rules
+             * Examples:
+             *   - 'backend-api' matches only 'backend-api'
+             *   - '^backend-.*' matches 'backend-api', 'backend-service', etc.
+             *   - '(?i)my-repo' for case-insensitive matching
+             */
+            name: string;
+            /**
+             * Optional list of file types to ingest for this repository. Overrides the global fileTypes setting for this repository only.
+             */
+            fileTypes?: string[];
+            /**
+             * Optional list of glob patterns to exclude files and directories from ingestion for this repository.
+             * Overrides the global pathExclusions setting for this repository only.
+             */
+            pathExclusions?: string[];
+          }[];
           /**
-           * Optional list of file types to ingest for this repository. Overrides the global fileTypes setting for this repository only.
+           * List of repositories to exclude from ingestion.
+           * Exclusions are applied after inclusions.
            */
-          fileTypes?: string[];
-          /**
-           * Optional list of glob patterns to exclude files and directories from ingestion for this repository.
-           * Overrides the global pathExclusions setting for this repository only.
-           */
-          pathExclusions?: string[];
-        }[];
+          exclude?: {
+            /**
+             * Repository name or regular expression pattern to exclude.
+             * All values are treated as regex patterns for matching:
+             * - Plain strings (e.g., 'test-repo') match exactly that string (case-sensitive)
+             * - Regex patterns (e.g., '^test-.*', '.*-archived$') match using regex rules
+             * Examples:
+             *   - 'temp-repo' matches only 'temp-repo'
+             *   - '^test-.*' matches 'test-api', 'test-service', etc.
+             *   - '(?i)archived' for case-insensitive matching
+             */
+            name: string;
+          }[];
+        };
         /**
          * Optional batch size for processing repository files. Defaults to 50 files per batch.
          * Lower values use less memory but may be slower, higher values are faster but use more memory.
@@ -59,14 +91,46 @@ export interface Config {
         pathExclusions?: string[];
 
         /**
-         * Optional list of wikis to ingest. If not specified, all wikis in the project will be ingested.
+         * Optional configuration for filtering wikis to ingest.
+         * If not specified, all wikis in the project will be ingested.
+         * Supports both exact name matching and regex patterns for flexible filtering.
          */
         wikis?: {
           /**
-           * The name of the wiki to ingest
+           * List of wikis to include for ingestion.
+           * If specified, only wikis matching these criteria will be ingested (unless excluded).
            */
-          name: string;
-        }[];
+          include?: {
+            /**
+             * Wiki name or regular expression pattern.
+             * All values are treated as regex patterns for matching:
+             * - Plain strings (e.g., 'my-wiki') match exactly that string (case-sensitive)
+             * - Regex patterns (e.g., '^prod-.*', '.*-docs$') match using regex rules
+             * Examples:
+             *   - 'production-wiki' matches only 'production-wiki'
+             *   - '^prod-.*' matches 'prod-wiki', 'prod-docs', etc.
+             *   - '(?i)docs' for case-insensitive matching
+             */
+            name: string;
+          }[];
+          /**
+           * List of wikis to exclude from ingestion.
+           * Exclusions are applied after inclusions.
+           */
+          exclude?: {
+            /**
+             * Wiki name or regular expression pattern to exclude.
+             * All values are treated as regex patterns for matching:
+             * - Plain strings (e.g., 'draft-wiki') match exactly that string (case-sensitive)
+             * - Regex patterns (e.g., '^draft-.*', '.*-test$') match using regex rules
+             * Examples:
+             *   - 'temp-wiki' matches only 'temp-wiki'
+             *   - '^draft-.*' matches 'draft-docs', 'draft-notes', etc.
+             *   - '(?i)test' for case-insensitive matching
+             */
+            name: string;
+          }[];
+        };
 
         /**
          * Optional batch size for processing wiki pages. Defaults to 50 pages per batch.

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
@@ -250,6 +250,12 @@ export const createRepositoryIngestor = async ({
 
     // If include matchers exist, only include repos that match at least one
     if (includeMatchers.length > 0) {
+      logger.info(
+        `Include filter found. Only including repositories matching the following patterns for ingestion: ${includeMatchers
+          .map(m => `'${m.value}'`)
+          .join(', ')}`,
+      );
+
       repositoriesToIngest = repositoriesToIngest.filter(repo => {
         return includeMatchers.some(matcher => matcher.regex!.test(repo.name!));
       });
@@ -257,9 +263,16 @@ export const createRepositoryIngestor = async ({
 
     // Apply exclusions
     if (excludeMatchers.length > 0) {
+      logger.info(
+        `Exclude filter found. Excluding repositories matching the following patterns from ingestion: ${excludeMatchers
+          .map(m => `'${m.value}'`)
+          .join(', ')}`,
+      );
+
       const excludedRepos = repositoriesToIngest.filter(repo => {
         return excludeMatchers.some(matcher => matcher.regex!.test(repo.name!));
       });
+
       if (excludedRepos.length > 0) {
         logger.info(
           `Excluding repositories: ${excludedRepos
@@ -280,6 +293,12 @@ export const createRepositoryIngestor = async ({
       );
       return;
     }
+
+    logger.debug(
+      `Repositories to ingest: ${repositoriesToIngest
+        .map(r => r.name)
+        .join(', ')}`,
+    );
 
     logger.info(
       `Ingesting ${repositoriesToIngest.length} repositories from Azure DevOps`,

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
@@ -53,7 +53,7 @@ export const createRepositoryIngestor = async ({
   if (repositoriesFilter?.include) {
     for (const filter of repositoriesFilter.include) {
       try {
-        // All strings are valid regex - plain strings match exactly, patterns match as regex
+        // All strings are treated as regular expression patterns; escape special characters for exact literal matches
         const regex = new RegExp(filter.name);
         includeMatchers.push({
           value: filter.name,

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/wiki.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/wiki.ts
@@ -45,7 +45,7 @@ export const createWikiIngestor = async ({
   if (wikisFilter?.include) {
     for (const filter of wikisFilter.include) {
       try {
-        // All strings are valid regex - plain strings match exactly, patterns match as regex
+        // All strings are treated as regex patterns; escape special characters for exact literal matches
         const regex = new RegExp(filter.name);
         includeMatchers.push({
           value: filter.name,

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/wiki.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/wiki.ts
@@ -226,6 +226,12 @@ export const createWikiIngestor = async ({
 
     // If include matchers exist, only include wikis that match at least one
     if (includeMatchers.length > 0) {
+      logger.info(
+        `Include filter found. Only including wikis matching the following patterns for ingestion: ${includeMatchers
+          .map(m => `'${m.value}'`)
+          .join(', ')}`,
+      );
+
       wikisToIngest = wikisToIngest.filter(wiki => {
         return includeMatchers.some(matcher => matcher.regex!.test(wiki.name!));
       });
@@ -233,9 +239,16 @@ export const createWikiIngestor = async ({
 
     // Apply exclusions
     if (excludeMatchers.length > 0) {
+      logger.info(
+        `Exclude filter found. Excluding wikis matching the following patterns from ingestion: ${excludeMatchers
+          .map(m => `'${m.value}'`)
+          .join(', ')}`,
+      );
+
       const excludedWikis = wikisToIngest.filter(wiki => {
         return excludeMatchers.some(matcher => matcher.regex!.test(wiki.name!));
       });
+
       if (excludedWikis.length > 0) {
         logger.info(
           `Excluding wikis: ${excludedWikis.map(w => w.name).join(', ')}`,
@@ -252,6 +265,10 @@ export const createWikiIngestor = async ({
       logger.warn('No wikis found for ingestion after applying the filter');
       return;
     }
+
+    logger.debug(
+      `Wikis to ingest: ${wikisToIngest.map(w => w.name).join(', ')}`,
+    );
 
     logger.info(`Ingesting ${wikisToIngest.length} wikis from Azure DevOps`);
 


### PR DESCRIPTION
This pull request introduces flexible include/exclude filtering for repositories and wikis in the Azure DevOps ingestor for the AI Assistant. The configuration now supports both exact and regex-based matching, allowing more granular control over which repositories and wikis are ingested. The implementation processes these filters, logs relevant information, and applies them during ingestion, replacing the previous exact name matching logic.

**Repository Filtering Enhancements:**

* Added support for `include` and `exclude` filters in the `aiAssistant` config for repositories, allowing both exact and regex-based matching patterns. This enables users to specify which repositories to ingest or ignore using flexible patterns.
* Updated the repository ingestor (`repository.ts`) to process and validate these filters, converting them into regex matchers and logging invalid patterns.
* Changed repository selection logic to use these matchers, filtering repositories for ingestion based on the new include/exclude rules and logging the results.
* Modified per-repository configuration application so that file types and path exclusions are determined by the matching include filter, rather than by exact name lookup.

**Wiki Filtering Enhancements:**

* Added support for `include` and `exclude` filters in the `aiAssistant` config for wikis, with both exact and regex-based matching. Updated the wiki ingestor (`wiki.ts`) to process, validate, and apply these filters, replacing previous exact name matching logic.