### PR TITLE
feat: update ingestion process to allow ingestors to set lastUpdated field for embeddings

### DIFF
--- a/.changeset/curvy-parts-fetch.md
+++ b/.changeset/curvy-parts-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend-module-ingestor-github': minor
+---
+
+Update github ingestion to set last updated field for embeddings

--- a/.changeset/cute-dryers-study.md
+++ b/.changeset/cute-dryers-study.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend-module-ingestor-azure-devops': minor
+---
+
+Update azure devops ingestion to set last updated field for embeddings

--- a/.changeset/nice-showers-appear.md
+++ b/.changeset/nice-showers-appear.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend': patch
+---
+
+Added ability for ingestors to set last updated field

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/azure-devops/index.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/azure-devops/index.ts
@@ -199,7 +199,7 @@ export const createAzureDevOpsService = async ({
    * Get the last updated date for a specific page in an Azure DevOps wiki
    * @param wikiId The ID of the wiki
    * @param pagePath The path of the page
-   * @returns The date when the wiki page was last updated
+   * @returns {Date | undefined} The date when the wiki page was last updated, or undefined if the committer date is not available
    */
   const getWikiPageLastUpdated = async (wikiId: string, pagePath: string) => {
     // Wikis in Azure DevOps are backed by Git repositories
@@ -212,9 +212,11 @@ export const createAzureDevOpsService = async ({
     }
 
     // Use Git API to get the last commit for the wiki page file
-    // Wiki pages are stored as .md files in the repository
+    // Wiki pages are typically stored as files in the repository (often .md)
     const filePath = pagePath.startsWith('/') ? pagePath.slice(1) : pagePath;
-    const fullPath = filePath.endsWith('.md') ? filePath : `${filePath}.md`;
+    const fileName = filePath.split('/').pop() ?? '';
+    const hasExtension = fileName.includes('.');
+    const fullPath = hasExtension ? filePath : `${filePath}.md`;
 
     const commits = await gitApi.getCommits(
       wiki.repositoryId,

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/azure-devops/index.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/azure-devops/index.ts
@@ -124,6 +124,26 @@ export const createAzureDevOpsService = async ({
     return itemContent;
   };
 
+  /**
+   * Get the last updated date for a specific item in an Azure DevOps repository
+   * @param repoId The ID of the repository
+   * @param path The path of the item
+   * @returns The date when the item was last updated
+   */
+  const getRepoItemLastUpdated = async (repoId: string, path: string) => {
+    const commits = await gitApi.getCommits(
+      repoId,
+      { itemPath: path, $top: 1 },
+      project,
+    );
+
+    if (!commits || commits.length === 0) {
+      throw new Error(`No commits found for item: ${path}`);
+    }
+
+    return commits[0].committer?.date;
+  };
+
   /* Gets all wikis in the specified Azure DevOps project */
   const getWikis = async () => {
     const wikis = await wikiApi.getAllWikis(project);
@@ -175,14 +195,50 @@ export const createAzureDevOpsService = async ({
     return pageStream;
   };
 
+  /**
+   * Get the last updated date for a specific page in an Azure DevOps wiki
+   * @param wikiId The ID of the wiki
+   * @param pagePath The path of the page
+   * @returns The date when the wiki page was last updated
+   */
+  const getWikiPageLastUpdated = async (wikiId: string, pagePath: string) => {
+    // Wikis in Azure DevOps are backed by Git repositories
+    // We need to get the wiki details first to access the repository
+    const wikis = await wikiApi.getAllWikis(project);
+    const wiki = wikis.find(w => w.id === wikiId);
+
+    if (!wiki?.repositoryId) {
+      throw new Error(`Could not find repository for wiki: ${wikiId}`);
+    }
+
+    // Use Git API to get the last commit for the wiki page file
+    // Wiki pages are stored as .md files in the repository
+    const filePath = pagePath.startsWith('/') ? pagePath.slice(1) : pagePath;
+    const fullPath = filePath.endsWith('.md') ? filePath : `${filePath}.md`;
+
+    const commits = await gitApi.getCommits(
+      wiki.repositoryId,
+      { itemPath: `/${fullPath}`, $top: 1 },
+      project,
+    );
+
+    if (!commits || commits.length === 0) {
+      throw new Error(`No commits found for wiki page: ${pagePath}`);
+    }
+
+    return commits[0].committer?.date;
+  };
+
   return {
     organization,
     project,
     getRepos,
     getRepoItems,
     getRepoItemContent,
+    getRepoItemLastUpdated,
     getWikis,
     getWikiPages,
     getWikiPageContent,
+    getWikiPageLastUpdated,
   };
 };

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts
@@ -190,10 +190,10 @@ export const createRepositoryIngestor = async ({
         const item = itemsBatch[index];
         const globalIndex = batchStart + index;
 
-        const content = await azureDevOpsService.getRepoItemContent(
-          repository.id!,
-          item.path!,
-        );
+        const [content, lastUpdated] = await Promise.all([
+          azureDevOpsService.getRepoItemContent(repository.id!, item.path!),
+          azureDevOpsService.getRepoItemLastUpdated(repository.id!, item.path!),
+        ]);
 
         const completionStats = getProgressStats(globalIndex + 1, items.length);
 
@@ -213,6 +213,7 @@ export const createRepositoryIngestor = async ({
             repository: repository.name!,
           },
           content: text,
+          lastUpdated,
         };
 
         documents.push(document);

--- a/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/wiki.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/wiki.ts
@@ -150,10 +150,10 @@ export const createWikiIngestor = async ({
         const page = pagesBatch[index];
         const globalIndex = batchStart + index;
 
-        const content = await azureDevOpsService.getWikiPageContent(
-          wiki.id!,
-          page.path!,
-        );
+        const [content, lastUpdated] = await Promise.all([
+          azureDevOpsService.getWikiPageContent(wiki.id!, page.path!),
+          azureDevOpsService.getWikiPageLastUpdated(wiki.id!, page.path!),
+        ]);
 
         const completionStats = getProgressStats(globalIndex + 1, pages.length);
 
@@ -188,6 +188,7 @@ export const createWikiIngestor = async ({
             wiki: wiki.name!,
           },
           content: pageContent,
+          lastUpdated,
         };
 
         logger.debug(

--- a/plugins/ai-assistant-backend-module-ingestor-github/src/services/github.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-github/src/services/github.ts
@@ -134,7 +134,7 @@ export const createGitHubService = async ({
    * Get the last updated date for a specific file
    * @param repoName The name of the repository
    * @param path The path of the file
-   * @returns The date when the file was last updated
+   * @returns The date when the file was last updated, or undefined if it cannot be determined
    */
   const getFileLastUpdated = async (repoName: string, path: string) => {
     const { data: commits } = await octokit.rest.repos.listCommits({

--- a/plugins/ai-assistant-backend-module-ingestor-github/src/services/github.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-github/src/services/github.ts
@@ -130,5 +130,32 @@ export const createGitHubService = async ({
     return content;
   };
 
-  return { owner, getRepos, getRepoFiles, getRepoFileContent };
+  /**
+   * Get the last updated date for a specific file
+   * @param repoName The name of the repository
+   * @param path The path of the file
+   * @returns The date when the file was last updated
+   */
+  const getFileLastUpdated = async (repoName: string, path: string) => {
+    const { data: commits } = await octokit.rest.repos.listCommits({
+      owner,
+      repo: repoName,
+      path,
+      per_page: 1,
+    });
+
+    if (commits.length === 0) {
+      throw new Error(`No commits found for file: ${path}`);
+    }
+
+    return commits[0].commit.committer?.date;
+  };
+
+  return {
+    owner,
+    getRepos,
+    getRepoFiles,
+    getRepoFileContent,
+    getFileLastUpdated,
+  };
 };

--- a/plugins/ai-assistant-backend-module-ingestor-github/src/services/ingestor.ts
+++ b/plugins/ai-assistant-backend-module-ingestor-github/src/services/ingestor.ts
@@ -117,10 +117,10 @@ export const createGitHubIngestor = async ({
         const globalIndex = batchStart + index;
 
         try {
-          const content = await githubService.getRepoFileContent(
-            repo.name,
-            file.path!,
-          );
+          const [content, lastUpdated] = await Promise.all([
+            githubService.getRepoFileContent(repo.name, file.path!),
+            githubService.getFileLastUpdated(repo.name, file.path!),
+          ]);
 
           const completionStats = getProgressStats(
             globalIndex + 1,
@@ -145,7 +145,7 @@ export const createGitHubIngestor = async ({
               ? `Repository Description: ${repo.description}`
               : ''
           }
-          
+
           Content:
           ${content}`;
 
@@ -162,6 +162,7 @@ export const createGitHubIngestor = async ({
               repositoryDescription: repo.description || '',
             },
             content: enhancedContent,
+            lastUpdated: lastUpdated ? new Date(lastUpdated) : undefined,
           };
 
           documents.push(document);

--- a/plugins/ai-assistant-backend/src/database/pg-vector-store.ts
+++ b/plugins/ai-assistant-backend/src/database/pg-vector-store.ts
@@ -165,7 +165,7 @@ export class PgVectorStore implements VectorStore {
         hash,
         id: doc.id ?? uuid(),
         metadata: doc.metadata,
-        lastUpdated: new Date(),
+        lastUpdated: doc.lastUpdated ?? new Date(),
         content: doc.content.replace(/\0/g, ''),
         vector: `[${vector.join(',')}]`,
       };

--- a/plugins/ai-assistant-backend/src/services/ingestor.ts
+++ b/plugins/ai-assistant-backend/src/services/ingestor.ts
@@ -86,6 +86,7 @@ export const createDataIngestionPipeline = ({
               (chunk, i) => ({
                 metadata: { ...document.metadata, chunk: String(i) },
                 content: chunk,
+                lastUpdated: document.lastUpdated,
               }),
             );
 


### PR DESCRIPTION
This pull request enhances the AI Assistant's ingestion modules for both GitHub and Azure DevOps by introducing support for tracking and storing the "last updated" timestamp for each ingested document. This enables more accurate metadata for embeddings and improves downstream data freshness and traceability. The changes span the backend, ingestor modules, and database layer.

**Ingestion pipeline and metadata improvements:**

* Added support for ingestors to set a `lastUpdated` field on documents, ensuring that the most recent modification date is tracked throughout the ingestion process (`plugins/ai-assistant-backend/src/services/ingestor.ts`, `plugins/ai-assistant-backend/src/database/pg-vector-store.ts`). [[1]](diffhunk://#diff-2bbdf418915f54aff77e38a537b3499132430ec0db52a7edaef3102d79b8f023R1-R5) [[2]](diffhunk://#diff-19daf4d2eaa5daba45ae02055b75ea4976e3efe23f72e3804dcf11851c8d070cR89) [[3]](diffhunk://#diff-11692943ea132576d72aa22774895a77f1603c537e88e59368c5ac7cdc5dacf9L168-R168)

**Azure DevOps ingestion enhancements:**

* Implemented `getRepoItemLastUpdated` and `getWikiPageLastUpdated` methods to fetch the last commit date for repository items and wiki pages, and updated repository and wiki ingestors to include this timestamp in document metadata (`plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/azure-devops/index.ts`, `plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/repository.ts`, `plugins/ai-assistant-backend-module-ingestor-azure-devops/src/services/ingestor/wiki.ts`). [[1]](diffhunk://#diff-345e9d0b4c0903d99da885c6f1a27fcdd1f7039955e3054fa134fc27afa4343dR1-R5) [[2]](diffhunk://#diff-e22808c5e76a7f5d5aebe7c1ec4a609d868c420729a8ddb8ee1bea2aa372d2e6R127-R146) [[3]](diffhunk://#diff-e22808c5e76a7f5d5aebe7c1ec4a609d868c420729a8ddb8ee1bea2aa372d2e6R198-R242) [[4]](diffhunk://#diff-50a874d3f4647b9cf1cef7b44eb07a1b41de41a0c5782fee944fff1451fd850fL193-R196) [[5]](diffhunk://#diff-50a874d3f4647b9cf1cef7b44eb07a1b41de41a0c5782fee944fff1451fd850fR216) [[6]](diffhunk://#diff-5360570fafcbc520f33b4f89fd50dfb8f9a46dbec08bb7433e9fc5692bacae0eL153-R156) [[7]](diffhunk://#diff-5360570fafcbc520f33b4f89fd50dfb8f9a46dbec08bb7433e9fc5692bacae0eR191)

**GitHub ingestion enhancements:**

* Added a `getFileLastUpdated` method to retrieve the last commit date for files via the GitHub API and updated the ingestor to include this timestamp in document metadata (`plugins/ai-assistant-backend-module-ingestor-github/src/services/github.ts`, `plugins/ai-assistant-backend-module-ingestor-github/src/services/ingestor.ts`). [[1]](diffhunk://#diff-1f73aa383c4b2b344a2fbdea19e730ef46e7e6fd62c08c99ae94323a77d4feeeR1-R5) [[2]](diffhunk://#diff-72858a28e8dade9e4cee7a3cf4fd0c8c29faaa449edacbc17c2c30707046706fL133-R160) [[3]](diffhunk://#diff-ed49557ecfd0eac31b395aad8bcc2270c68f1cf0d6f9b5d41c66dec67e05d6c1L120-R123) [[4]](diffhunk://#diff-ed49557ecfd0eac31b395aad8bcc2270c68f1cf0d6f9b5d41c66dec67e05d6c1R165)

**Changelog updates:**

* Updated changeset files to document the new minor and patch releases for the affected packages. [[1]](diffhunk://#diff-1f73aa383c4b2b344a2fbdea19e730ef46e7e6fd62c08c99ae94323a77d4feeeR1-R5) [[2]](diffhunk://#diff-345e9d0b4c0903d99da885c6f1a27fcdd1f7039955e3054fa134fc27afa4343dR1-R5) [[3]](diffhunk://#diff-2bbdf418915f54aff77e38a537b3499132430ec0db52a7edaef3102d79b8f023R1-R5)