### PR TITLE
feat: implement analytics tracking and allow query param for initial message

### DIFF
--- a/plugins/ai-assistant/src/hooks/index.ts
+++ b/plugins/ai-assistant/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './use-chat-settings';
 export * from './use-page-summary';
+export * from './use-analytics';

--- a/plugins/ai-assistant/src/hooks/use-analytics.ts
+++ b/plugins/ai-assistant/src/hooks/use-analytics.ts
@@ -1,0 +1,33 @@
+import { analyticsApiRef, useApi } from '@backstage/core-plugin-api';
+
+type CaptureEventOptions = {
+  action: string;
+  subject: string;
+  attributes?: Record<string, string | boolean | number>;
+  context?: Record<string, string | boolean | number | undefined>;
+};
+
+export const useAnalytics = () => {
+  const analyticsApi = useApi(analyticsApiRef);
+
+  const captureEvent = ({
+    action,
+    subject,
+    attributes = {},
+    context = {},
+  }: CaptureEventOptions) => {
+    analyticsApi.captureEvent({
+      action: `ai_assistant_${action}`,
+      subject,
+      context: {
+        extension: 'ai-assistant',
+        pluginId: 'ai-assistant',
+        routeRef: 'ai-assistant',
+        ...context,
+      },
+      attributes,
+    });
+  };
+
+  return { captureEvent };
+};


### PR DESCRIPTION
This pull request introduces analytics tracking to the AI Assistant's conversation component, enabling the capture of user interactions such as sending and receiving messages. It also adds support for initializing the chat input from a URL query parameter and cleans up the query parameter after use. The changes are grouped into analytics integration and user experience improvements.

**Analytics integration:**

* Added a new `useAnalytics` hook (`use-analytics.ts`) to provide a simple interface for capturing analytics events using Backstage's `analyticsApiRef`.
* Integrated analytics tracking into the `Conversation` component to capture events when messages are sent (`message_sent`) and when non-human messages are received (`message_received`), including the model ID as the subject. [[1]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R89-R95) [[2]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R139-R143) [[3]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06L18-R19) [[4]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06L85-R106)

**User experience improvements:**

* Updated the `Conversation` component to initialize the chat input from a `query` URL parameter and remove the parameter after use, supporting deep linking and cleaner URLs. [[1]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R6) [[2]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R35-R51)

**Other:**

* Exported the new `useAnalytics` hook in the hooks index for easier import elsewhere.