### PR TITLE
feat: make core and default-enabled tools configurable via app config

### DIFF
--- a/plugins/ai-assistant-backend/README.md
+++ b/plugins/ai-assistant-backend/README.md
@@ -41,10 +41,10 @@ aiAssistant:
   tools:
     core:
       - provider: core
-        name: searchKnowledge
+        name: search-knowledge-base
     defaultEnabled:
       - provider: core
-        name: searchKnowledge
+        name: search-knowledge-base
       - provider: mcp server:foo
         name: foo_someTool
 ```

--- a/plugins/ai-assistant-backend/README.md
+++ b/plugins/ai-assistant-backend/README.md
@@ -26,3 +26,27 @@ package with `yarn start`. It is a limited setup that is most convenient when
 developing the plugin backend itself.
 
 If you want to run the entire project, including the frontend, run `yarn start` from the root directory.
+
+## Tool Configuration
+
+You can control tool behavior for all users through backend config:
+
+- `aiAssistant.tools.core`: tools that are always enabled and not user-toggleable.
+- `aiAssistant.tools.defaultEnabled`: tools enabled by default for users who do not yet have saved `user-tools` settings.
+
+Both settings accept entries with `provider` and `name`:
+
+```yaml
+aiAssistant:
+  tools:
+    core:
+      - provider: core
+        name: searchKnowledge
+    defaultEnabled:
+      - provider: core
+        name: searchKnowledge
+      - provider: mcp server:foo
+        name: foo_someTool
+```
+
+For MCP tools, use provider format `mcp server:<server-name>`.

--- a/plugins/ai-assistant-backend/config.d.ts
+++ b/plugins/ai-assistant-backend/config.d.ts
@@ -45,6 +45,28 @@ export interface Config {
         maxChunkProcessingSize?: number;
       };
     };
+    tools?: {
+      /**
+       * List of tools that should always be enabled and not user-toggleable.
+       *
+       * For MCP tools, provider format is: `mcp server:<server-name>`.
+       */
+      core?: Array<{
+        provider: string;
+        name: string;
+      }>;
+
+      /**
+       * List of tools enabled by default for users that don't have existing
+       * `user-tools` settings.
+       *
+       * For MCP tools, provider format is: `mcp server:<server-name>`.
+       */
+      defaultEnabled?: Array<{
+        provider: string;
+        name: string;
+      }>;
+    };
     mcp: {
       /**
        * @visibility secret

--- a/plugins/ai-assistant-backend/src/services/tools.ts
+++ b/plugins/ai-assistant-backend/src/services/tools.ts
@@ -95,7 +95,7 @@ const createToolsService = async ({
       return resolvedCore;
     }
 
-    return allTools.filter(tool =>
+    const resolvedConfiguredDefaultTools = allTools.filter(tool =>
       configuredDefaultTools.some(configuredTool =>
         areSameTools(configuredTool, {
           name: tool.name,
@@ -103,6 +103,8 @@ const createToolsService = async ({
         }),
       ),
     );
+
+    return uniqTools(resolvedConfiguredDefaultTools.concat(resolvedCore));
   };
 
   const registerTools: ToolsService['registerTools'] = async providers => {

--- a/plugins/ai-assistant-backend/src/services/tools.ts
+++ b/plugins/ai-assistant-backend/src/services/tools.ts
@@ -5,6 +5,7 @@ import {
   createServiceRef,
   ServiceRef,
   AuthService,
+  RootConfigService,
 } from '@backstage/backend-plugin-api';
 import {
   Tool,
@@ -28,14 +29,81 @@ export type ToolsService = {
 export type CreateToolsServiceOptions = {
   mcp: McpService;
   auth: AuthService;
+  config: RootConfigService;
 };
+
+type ToolSelector = Pick<EnabledTool, 'name' | 'provider'>;
 
 const createToolsService = async ({
   mcp,
   auth,
+  config,
 }: CreateToolsServiceOptions): Promise<ToolsService> => {
   const tools: Tool[] = [];
   const coreTools: Tool[] = [];
+
+  const areSameTools = (left: ToolSelector, right: ToolSelector) =>
+    left.name === right.name && left.provider === right.provider;
+
+  const getConfiguredTools = (path: string): ToolSelector[] | undefined => {
+    const configuredTools = config.getOptionalConfigArray(path);
+
+    if (!configuredTools) {
+      return undefined;
+    }
+
+    return configuredTools.map(tool => ({
+      name: tool.getString('name'),
+      provider: tool.getString('provider'),
+    }));
+  };
+
+  const uniqTools = (allTools: Tool[]): Tool[] => {
+    const toolMap = new Map(
+      allTools.map(tool => [`${tool.provider}:${tool.name}`, tool]),
+    );
+
+    return Array.from(toolMap.values());
+  };
+
+  const resolveCoreTools = (allTools: Tool[]): Tool[] => {
+    const configuredCoreTools = getConfiguredTools('aiAssistant.tools.core');
+
+    if (configuredCoreTools === undefined) {
+      return coreTools;
+    }
+
+    return allTools.filter(tool =>
+      configuredCoreTools.some(configuredTool =>
+        areSameTools(configuredTool, {
+          name: tool.name,
+          provider: tool.provider,
+        }),
+      ),
+    );
+  };
+
+  const resolveDefaultEnabledTools = (
+    allTools: Tool[],
+    resolvedCore: Tool[],
+  ) => {
+    const configuredDefaultTools = getConfiguredTools(
+      'aiAssistant.tools.defaultEnabled',
+    );
+
+    if (configuredDefaultTools === undefined) {
+      return resolvedCore;
+    }
+
+    return allTools.filter(tool =>
+      configuredDefaultTools.some(configuredTool =>
+        areSameTools(configuredTool, {
+          name: tool.name,
+          provider: tool.provider,
+        }),
+      ),
+    );
+  };
 
   const registerTools: ToolsService['registerTools'] = async providers => {
     tools.push(...providers);
@@ -51,16 +119,33 @@ const createToolsService = async ({
   }) => {
     const mcpTools = await mcp.getTools(credentials);
 
-    const availableTools: EnabledTool[] = tools
-      .concat(mcpTools)
-      .concat(coreTools)
-      .map(tool => ({
-        name: tool.name,
-        provider: tool.provider,
-        description: tool.description,
-      }));
+    const availableTools = uniqTools(tools.concat(mcpTools).concat(coreTools));
 
-    return availableTools;
+    const resolvedCoreTools = resolveCoreTools(availableTools);
+    const resolvedDefaultEnabledTools = resolveDefaultEnabledTools(
+      availableTools,
+      resolvedCoreTools,
+    );
+
+    const availableUserTools: EnabledTool[] = availableTools.map(tool => ({
+      name: tool.name,
+      provider: tool.provider,
+      description: tool.description,
+      isCore: resolvedCoreTools.some(coreTool =>
+        areSameTools(coreTool, {
+          name: tool.name,
+          provider: tool.provider,
+        }),
+      ),
+      enabledByDefault: resolvedDefaultEnabledTools.some(defaultTool =>
+        areSameTools(defaultTool, {
+          name: tool.name,
+          provider: tool.provider,
+        }),
+      ),
+    }));
+
+    return availableUserTools;
   };
 
   const getPrincipalTools: ToolsService['getPrincipalTools'] = async ({
@@ -75,11 +160,23 @@ const createToolsService = async ({
 
     const mcpTools = await mcp.getTools(credentials);
 
-    const userTools = tools.concat(mcpTools);
+    const availableTools = uniqTools(tools.concat(mcpTools).concat(coreTools));
+    const resolvedCoreTools = resolveCoreTools(availableTools);
 
-    const allTools: Tool[] = userTools
-      .filter(filter)
-      .concat(coreTools.filter(filter));
+    const userSelectableTools = availableTools.filter(
+      tool =>
+        !resolvedCoreTools.some(coreTool =>
+          areSameTools(coreTool, {
+            name: tool.name,
+            provider: tool.provider,
+          }),
+        ),
+    );
+
+    const allTools: Tool[] = uniqTools(
+      userSelectableTools.filter(filter).concat(resolvedCoreTools),
+    );
+
     return allTools.map(t => new DynamicStructuredTool(t));
   };
 
@@ -100,6 +197,7 @@ export const toolsServiceRef: ServiceRef<ToolsService, 'plugin', 'singleton'> =
         deps: {
           mcp: mcpServiceRef,
           auth: coreServices.auth,
+          config: coreServices.rootConfig,
         },
         factory: async options => {
           return createToolsService(options);

--- a/plugins/ai-assistant-common/src/types/tool.ts
+++ b/plugins/ai-assistant-common/src/types/tool.ts
@@ -12,4 +12,7 @@ export type Tool<T extends ZodType<any, any, any> = ZodType<any, any, any>> = {
   }>;
 };
 
-export type EnabledTool = Pick<Tool, 'name' | 'provider' | 'description'>;
+export type EnabledTool = Pick<Tool, 'name' | 'provider' | 'description'> & {
+  isCore?: boolean;
+  enabledByDefault?: boolean;
+};

--- a/plugins/ai-assistant/src/components/SettingsModal/tabs/Tools/Tools.tsx
+++ b/plugins/ai-assistant/src/components/SettingsModal/tabs/Tools/Tools.tsx
@@ -103,12 +103,15 @@ export const Tab = () => {
       return;
     }
 
-    const providerToolStrings = new Set(
-      providerTools.filter(tool => !tool.isCore).map(t => JSON.stringify(t)),
+    const providerToolKeys = new Set(
+      providerTools
+        .filter(tool => !tool.isCore)
+        .map(tool => `${tool.provider}:${tool.name}`),
     );
     setToolsEnabled(
       toolsEnabled.filter(
-        (tool: EnabledTool) => !providerToolStrings.has(JSON.stringify(tool)),
+        (tool: EnabledTool) =>
+          !providerToolKeys.has(`${tool.provider}:${tool.name}`),
       ),
     );
   };

--- a/plugins/ai-assistant/src/components/SettingsModal/tabs/Tools/Tools.tsx
+++ b/plugins/ai-assistant/src/components/SettingsModal/tabs/Tools/Tools.tsx
@@ -104,11 +104,11 @@ export const Tab = () => {
     }
 
     const providerToolStrings = new Set(
-      providerTools.map(t => JSON.stringify(t)),
+      providerTools.filter(tool => !tool.isCore).map(t => JSON.stringify(t)),
     );
     setToolsEnabled(
       toolsEnabled.filter(
-        tool => !providerToolStrings.has(JSON.stringify(tool)),
+        (tool: EnabledTool) => !providerToolStrings.has(JSON.stringify(tool)),
       ),
     );
   };
@@ -124,7 +124,8 @@ export const Tab = () => {
 
     setToolsEnabled(
       toolsEnabled.filter(
-        t => !(t.name === tool.name && t.provider === tool.provider),
+        (t: EnabledTool) =>
+          !(t.name === tool.name && t.provider === tool.provider),
       ),
     );
   };
@@ -164,12 +165,15 @@ export const Tab = () => {
                 onChange={(_e, checked) =>
                   handleProviderClick(provider, checked)
                 }
-                disabled={provider === 'core'}
+                disabled={availableUserTools!
+                  .filter(tool => tool.provider === provider)
+                  .every(tool => tool.isCore)}
                 checked={availableUserTools!
                   .filter(tool => tool.provider === provider)
                   .every(tool =>
                     toolsEnabled?.some(
-                      t => t.name === tool.name && t.provider === tool.provider,
+                      (t: EnabledTool) =>
+                        t.name === tool.name && t.provider === tool.provider,
                     ),
                   )}
               />
@@ -182,12 +186,12 @@ export const Tab = () => {
                       label={tool.name}
                       checked={
                         toolsEnabled?.some(
-                          t =>
+                          (t: EnabledTool) =>
                             t.name === tool.name &&
                             t.provider === tool.provider,
                         ) || false
                       }
-                      disabled={tool.provider === 'core'}
+                      disabled={tool.isCore}
                       onChange={(_e, checked) => handleToolClick(tool, checked)}
                     />
                   </Tooltip>

--- a/plugins/ai-assistant/src/hooks/use-chat-settings.ts
+++ b/plugins/ai-assistant/src/hooks/use-chat-settings.ts
@@ -99,15 +99,17 @@ export const useChatSettings = () => {
 
     const availableTools = await getAvailableTools();
 
-    const coreTools = availableTools.filter(tool => tool.provider === 'core');
+    const defaultEnabledTools = availableTools.filter(
+      tool => tool.enabledByDefault,
+    );
 
-    setToolsEnabledState(coreTools);
+    setToolsEnabledState(defaultEnabledTools);
     // Persist to backend
     await fetchApi.fetch(`${baseUrl}/settings`, {
       method: 'PATCH',
       body: JSON.stringify({
         type: 'user-tools',
-        settings: { tools: coreTools },
+        settings: { tools: defaultEnabledTools },
       }),
       headers: { 'Content-Type': 'application/json' },
     });


### PR DESCRIPTION

![Recording 2026-03-03 092601](https://github.com/user-attachments/assets/901da696-e54a-4078-ae2b-bb8f365b030e)


This pull request introduces backend configuration for tool availability and default enablement in the AI Assistant plugin. It allows administrators to centrally control which tools are always enabled (core tools) and which are enabled by default for users, improving flexibility and user experience. The frontend and backend are updated to respect these settings, ensuring core tools are not user-toggleable and default-enabled tools are pre-selected for new users.