### PR TITLE
feat: button shake animation on the gear icon

### DIFF
--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -275,6 +275,18 @@ export const Conversation = ({
             color="info"
             title="Settings"
             onClick={() => setSettingsModalOpen(true)}
+            sx={{
+              '@keyframes jump-shaking': {
+                '0%': { transform: 'translateX(0)' },
+                '25%': { transform: 'translateY(-9px)' },
+                '35%': { transform: 'translateY(-9px) rotate(17deg)' },
+                '55%': { transform: 'translateY(-9px) rotate(-17deg)' },
+                '65%': { transform: 'translateY(-9px) rotate(17deg)' },
+                '75%': { transform: 'translateY(-9px) rotate(-17deg)' },
+                '100%': { transform: 'translateY(0) rotate(0)' },
+              },
+              animation: 'jump-shaking 1s ease-in-out 2',
+            }}
           >
             <SettingsIcon />
           </Button>

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -277,7 +277,11 @@ export const Conversation = ({
             title="Settings"
             aria-label="Settings"
             onClick={() => {
-              localStorage.setItem('settingsButtonClicked', 'true');
+              try {
+                localStorage.setItem('settingsButtonClicked', 'true');
+              } catch (_error) {
+                // Ignore storage errors (e.g., blocked or unavailable localStorage)
+              }
               setSettingsButtonClicked(true);
               setSettingsModalOpen(true);
             }}

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -1,7 +1,12 @@
-import { useApi, errorApiRef } from '@backstage/core-plugin-api';
+import { useApi, errorApiRef, storageApiRef } from '@backstage/core-plugin-api';
 import { chatApiRef } from '../../api/chat';
-import { useAsync, useAsyncFn, useLocalStorage } from 'react-use';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useAsync,
+  useAsyncFn,
+  useLocalStorage,
+  useObservable,
+} from 'react-use';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { signalApiRef } from '@backstage/plugin-signals-react';
 import { useSearchParams } from 'react-router-dom';
 
@@ -23,7 +28,7 @@ type ConversationOptions = {
   setConversationId: (id: string) => void;
   additionalSystemMessages?: Message[];
 };
-
+const SETTINGS_BUTTON_CLICKED_KEY = 'ai-assistant.settings-button-clicked';
 export const Conversation = ({
   conversationId,
   setConversationId,
@@ -32,6 +37,9 @@ export const Conversation = ({
   const chatApi = useApi(chatApiRef);
   const errorApi = useApi(errorApiRef);
   const signalApi = useApi(signalApiRef);
+  const storageApi = useApi(storageApiRef).forBucket(
+    SETTINGS_BUTTON_CLICKED_KEY,
+  );
   const analytics = useAnalytics();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -55,12 +63,23 @@ export const Conversation = ({
   );
 
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
-  const [settingsButtonClicked, setSettingsButtonClicked] =
-    useLocalStorage<boolean>('settingsButtonClicked', false);
   const { value: models, loading: loadingModels } = useAsync(
     () => chatApi.getModels(),
     [chatApi],
   );
+  const settingsButtonClickedSnapshot = useObservable(
+    storageApi.observe$(SETTINGS_BUTTON_CLICKED_KEY),
+    storageApi.snapshot(SETTINGS_BUTTON_CLICKED_KEY),
+  );
+  const settingsButtonClicked = useMemo(() => {
+    if (
+      !settingsButtonClickedSnapshot ||
+      settingsButtonClickedSnapshot.presence === 'absent'
+    ) {
+      return false;
+    }
+    return (settingsButtonClickedSnapshot.value as boolean) ?? false;
+  }, [settingsButtonClickedSnapshot]);
 
   const { value: history, loading: loadingHistory } = useAsync(
     () => chatApi.getConversation(conversationId),
@@ -277,12 +296,15 @@ export const Conversation = ({
             title="Settings"
             aria-label="Settings"
             onClick={() => {
-              try {
-                localStorage.setItem('settingsButtonClicked', 'true');
-              } catch (_error) {
-                // Ignore storage errors (e.g., blocked or unavailable localStorage)
-              }
-              setSettingsButtonClicked(true);
+              storageApi.set(SETTINGS_BUTTON_CLICKED_KEY, true).catch(err => {
+                errorApi.post({
+                  message: `Failed to update settings button state: ${
+                    (err as Error).message
+                  }. This will cause the settings button animation to still play on every render. Please try again.`,
+                  name: 'SettingsButtonStateError',
+                });
+              });
+
               setSettingsModalOpen(true);
             }}
             sx={{

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -55,6 +55,13 @@ export const Conversation = ({
   );
 
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
+  const [settingsButtonClicked, setSettingsButtonClicked] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return localStorage.getItem('settingsButtonClicked') === 'true';
+  });
 
   const { value: models, loading: loadingModels } = useAsync(
     () => chatApi.getModels(),
@@ -274,7 +281,11 @@ export const Conversation = ({
             variant="contained"
             color="info"
             title="Settings"
-            onClick={() => setSettingsModalOpen(true)}
+            onClick={() => {
+              localStorage.setItem('settingsButtonClicked', 'true');
+              setSettingsButtonClicked(true);
+              setSettingsModalOpen(true);
+            }}
             sx={{
               '@keyframes jump-shaking': {
                 '0%': { transform: 'translateX(0)' },
@@ -285,7 +296,9 @@ export const Conversation = ({
                 '75%': { transform: 'translateY(-9px) rotate(-17deg)' },
                 '100%': { transform: 'translateY(0) rotate(0)' },
               },
-              animation: 'jump-shaking 1s ease-in-out 2',
+              animation: settingsButtonClicked
+                ? 'none'
+                : 'jump-shaking 1s ease-in-out 2',
             }}
           >
             <SettingsIcon />

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -55,14 +55,8 @@ export const Conversation = ({
   );
 
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
-  const [settingsButtonClicked, setSettingsButtonClicked] = useState(() => {
-    if (typeof window === 'undefined') {
-      return false;
-    }
-
-    return localStorage.getItem('settingsButtonClicked') === 'true';
-  });
-
+  const [settingsButtonClicked, setSettingsButtonClicked] =
+    useLocalStorage<boolean>('settingsButtonClicked', false);
   const { value: models, loading: loadingModels } = useAsync(
     () => chatApi.getModels(),
     [chatApi],
@@ -281,6 +275,7 @@ export const Conversation = ({
             variant="contained"
             color="info"
             title="Settings"
+            aria-label="Settings"
             onClick={() => {
               localStorage.setItem('settingsButtonClicked', 'true');
               setSettingsButtonClicked(true);
@@ -299,6 +294,9 @@ export const Conversation = ({
               animation: settingsButtonClicked
                 ? 'none'
                 : 'jump-shaking 1s ease-in-out 2',
+              '@media (prefers-reduced-motion: reduce)': {
+                animation: 'none',
+              },
             }}
           >
             <SettingsIcon />


### PR DESCRIPTION


https://github.com/user-attachments/assets/29c148e2-6dc9-4206-bc27-2134040104fd



This pull request enhances the user experience for the settings button in the AI Assistant conversation component by adding a one-time animation to draw attention to the button, and persisting the animation state using local storage. It also improves error handling and accessibility for the button.

**User experience improvements:**

* Added a "jump-shaking" animation to the settings button that plays only the first time the button is rendered, drawing user attention to the settings feature. The animation is disabled after the button is clicked, and respects the user's reduced motion preference.

**State persistence and error handling:**

* Integrated `storageApi` to persist the state of whether the settings button has been clicked (`SETTINGS_BUTTON_CLICKED_KEY`), ensuring the animation only plays once per user. [[1]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06L26-R31) [[2]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R40-R42) [[3]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06L58-R82)
* Added error handling to report failures when updating the settings button state, improving robustness.

**Accessibility improvements:**

* Added `aria-label="Settings"` to the settings button for improved accessibility.