### PR TITLE
feat: add optional apiKey to model configuration for Azure AI

### DIFF
--- a/.changeset/few-friends-brake.md
+++ b/.changeset/few-friends-brake.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend-module-model-provider-azure-ai': minor
+---
+
+add optional apiKey to model configuration for Azure AI

--- a/plugins/ai-assistant-backend-module-model-provider-azure-ai/config.d.ts
+++ b/plugins/ai-assistant-backend-module-model-provider-azure-ai/config.d.ts
@@ -12,6 +12,7 @@ export interface Config {
           modelName: string;
           endpoint: string;
           sdk?: SdkType;
+          apiKey?: string;
         }[];
       };
     };

--- a/plugins/ai-assistant-backend-module-model-provider-azure-ai/src/module.ts
+++ b/plugins/ai-assistant-backend-module-model-provider-azure-ai/src/module.ts
@@ -29,9 +29,10 @@ export const aiAssistantModuleModelProviderAzureAi = createBackendModule({
             const endpoint = modelConfig.getString('endpoint');
             const modelName = modelConfig.getString('modelName');
             const sdk = modelConfig.getOptionalString('sdk') ?? 'openai';
+            const modelApiKey = modelConfig.getOptionalString('apiKey');
 
             const chatModel = createChatModeForSdk(sdk, {
-              apiKey,
+              apiKey: modelApiKey ?? apiKey,
               endpoint,
               modelName,
             });


### PR DESCRIPTION
This pull request introduces a minor update to the Azure AI model provider backend module, allowing for more flexible API key configuration. The main change enables specifying an optional `apiKey` directly in the model configuration, which can override the global API key.

Configuration enhancements:

* Added support for an optional `apiKey` in the model configuration for Azure AI. If provided, this key will be used for the specific model instance; otherwise, the global API key is used. (`plugins/ai-assistant-backend-module-model-provider-azure-ai/src/module.ts`, `.changeset/few-friends-brake.md`) [[1]](diffhunk://#diff-d7fba11b770b281d4b420bbf941d02b1949716a838535c152b533a1dcf14da57R32-R35) [[2]](diffhunk://#diff-7ab9b07d1599a29375a6245d59c0e225d5e5c36089555aafc31dd8edfd3f3a45R1-R5)