### PR TITLE
feat: implement auto-scroll behavior and user notification for new me…

### DIFF
--- a/.changeset/hip-deer-leave.md
+++ b/.changeset/hip-deer-leave.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant': minor
+---
+
+Improve conversation experience by refining message rendering and interaction behavior in the AI Assistant UI.

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -321,7 +321,7 @@ export const Conversation = ({
           onClick={() => scrollToBottom('smooth')}
           sx={{ alignSelf: 'center' }}
         >
-          Jump to latest ↓
+          Scroll to bottom ↓
         </Button>
       )}
 

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -28,6 +28,9 @@ type ConversationOptions = {
   setConversationId: (id: string) => void;
   additionalSystemMessages?: Message[];
 };
+
+const SCROLL_BOTTOM_THRESHOLD_PX = 80;
+
 const SETTINGS_BUTTON_CLICKED_KEY = 'ai-assistant.settings-button-clicked';
 export const Conversation = ({
   conversationId,
@@ -204,10 +207,52 @@ export const Conversation = ({
   ]);
 
   const messageEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const [isUserAtBottom, setIsUserAtBottom] = useState(true);
+  const isUserAtBottomRef = useRef(true);
+
+  const getIsNearBottom = useCallback((element: HTMLDivElement) => {
+    const distanceToBottom =
+      element.scrollHeight - element.scrollTop - element.clientHeight;
+    return distanceToBottom <= SCROLL_BOTTOM_THRESHOLD_PX;
+  }, []);
+
+  const syncUserAtBottom = useCallback((value: boolean) => {
+    isUserAtBottomRef.current = value;
+    setIsUserAtBottom(value);
+  }, []);
+
+  const handleMessagesScroll = useCallback(() => {
+    if (!messagesContainerRef.current) {
+      return;
+    }
+
+    syncUserAtBottom(getIsNearBottom(messagesContainerRef.current));
+  }, [getIsNearBottom, syncUserAtBottom]);
+
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'auto') => {
+      messageEndRef.current?.scrollIntoView({ behavior });
+      syncUserAtBottom(true);
+    },
+    [syncUserAtBottom],
+  );
 
   useEffect(() => {
-    messageEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+    if (!isUserAtBottomRef.current) {
+      return;
+    }
+
+    scrollToBottom('auto');
+  }, [messages, scrollToBottom]);
+
+  useEffect(() => {
+    if (!messagesContainerRef.current) {
+      return;
+    }
+
+    syncUserAtBottom(getIsNearBottom(messagesContainerRef.current));
+  }, [messages, getIsNearBottom, syncUserAtBottom]);
 
   if (loadingHistory && loadingModels) {
     return <Typography>Loading...</Typography>;
@@ -228,6 +273,8 @@ export const Conversation = ({
     >
       {messages && (
         <Stack
+          ref={messagesContainerRef}
+          onScroll={handleMessagesScroll}
           spacing={1}
           flex={1}
           sx={theme => ({
@@ -266,6 +313,16 @@ export const Conversation = ({
             )}
           <div ref={messageEndRef} />
         </Stack>
+      )}
+
+      {!isUserAtBottom && messages.length > 0 && (
+        <Button
+          variant="outlined"
+          onClick={() => scrollToBottom('smooth')}
+          sx={{ alignSelf: 'center' }}
+        >
+          Jump to latest ↓
+        </Button>
       )}
 
       <Paper elevation={2} sx={{ padding: 1 }}>


### PR DESCRIPTION


https://github.com/user-attachments/assets/264c4c9c-5ff2-47e2-8175-19a02bc65fe7


This pull request enhances the user experience in the AI Assistant's conversation view by improving how scrolling and new message visibility are handled. The main update ensures users are not automatically scrolled to the bottom when new messages arrive unless they are already near the bottom, and provides a convenient button to jump to the latest messages if needed.

**Improvements to scrolling behavior and user experience:**

* Added logic to track whether the user is near the bottom of the messages list using a new `isUserAtBottom` state, and only auto-scrolls when appropriate.
* Introduced a "Jump to latest" button that appears when the user is not at the bottom, allowing them to quickly scroll to the newest messages.

**Code structure and maintainability:**

* Added a `SCROLL_BOTTOM_THRESHOLD_PX` constant to define how close to the bottom the user must be to trigger auto-scroll.
* Refactored the message container to use a `ref` and handle `onScroll` events, enabling real-time tracking of scroll position.
* Improved effect hooks to synchronize scroll state and ensure consistent behavior when messages update.