### PR TITLE
feat: add URL query parameter support for auto-sending messages

### DIFF
--- a/.changeset/olive-rice-study.md
+++ b/.changeset/olive-rice-study.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant': minor
+---
+
+Add optional autoSend query parameter to control automatic message sending. The ?query= parameter now pre-populates the input without auto-sending by default. Use ?query=text&autoSend=true to enable automatic sending for browser search engine integration.

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -47,7 +47,7 @@ export const Conversation = ({
 
   const [input, setInput] = useState(initialQuery);
   const inputRef = useRef<HTMLInputElement>(null);
-  const autoSentRef = useRef(false); 
+  const autoSentRef = useRef(false);
 
   // Clean up URL parameters after pre-populating (always, not just on auto-send)
   useEffect(() => {
@@ -211,8 +211,6 @@ export const Conversation = ({
     errorApi,
     setInput,
     toolsEnabled,
-    analytics,
-    additionalSystemMessages,
   ]);
 
   // Auto-send only when autoSend=true parameter is present

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -197,17 +197,33 @@ export const Conversation = ({
     additionalSystemMessages,
   ]);
 
-  // Auto-send initial query
+  // CHANGED: Auto-send only when autoSend=true parameter is present
   useEffect(() => {
-    if (initialQuery && !autoSentRef.current && modelId && !loadingHistory) {
+    const autoSend = searchParams.get('autoSend') === 'true'; // ADDED THIS LINE
+
+    if (
+      initialQuery &&
+      autoSend &&
+      !autoSentRef.current &&
+      modelId &&
+      !loadingHistory
+    ) {
       autoSentRef.current = true;
       sendMessage();
       setSearchParams(params => {
         params.delete('query');
+        params.delete('autoSend'); // ADDED: Also clean up autoSend param
         return params;
       });
     }
-  }, [initialQuery, modelId, loadingHistory, sendMessage, setSearchParams]);
+  }, [
+    initialQuery,
+    modelId,
+    loadingHistory,
+    sendMessage,
+    setSearchParams,
+    searchParams,
+  ]);
 
   const messageEndRef = useRef<HTMLDivElement>(null);
 

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -47,7 +47,25 @@ export const Conversation = ({
 
   const [input, setInput] = useState(initialQuery);
   const inputRef = useRef<HTMLInputElement>(null);
-  const autoSentRef = useRef(false);
+  const autoSentRef = useRef(false); 
+
+  // Clean up URL parameters after pre-populating (always, not just on auto-send)
+  useEffect(() => {
+    if (
+      initialQuery &&
+      (searchParams.has('query') || searchParams.has('autoSend'))
+    ) {
+      const timer = setTimeout(() => {
+        setSearchParams(params => {
+          params.delete('query');
+          params.delete('autoSend');
+          return params;
+        });
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [initialQuery, searchParams, setSearchParams]);
 
   const [modelId, setModelId] = useLocalStorage<string | undefined>(
     'modelId',
@@ -199,7 +217,7 @@ export const Conversation = ({
 
   // Auto-send only when autoSend=true parameter is present
   useEffect(() => {
-    const autoSend = searchParams.get('autoSend') === 'true'; 
+    const autoSend = searchParams.get('autoSend') === 'true';
 
     if (
       initialQuery &&
@@ -210,20 +228,8 @@ export const Conversation = ({
     ) {
       autoSentRef.current = true;
       sendMessage();
-      setSearchParams(params => {
-        params.delete('query');
-        params.delete('autoSend'); 
-        return params;
-      });
     }
-  }, [
-    initialQuery,
-    modelId,
-    loadingHistory,
-    sendMessage,
-    setSearchParams,
-    searchParams,
-  ]);
+  }, [initialQuery, modelId, loadingHistory, sendMessage, searchParams]);
 
   const messageEndRef = useRef<HTMLDivElement>(null);
 

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -44,32 +44,11 @@ export const Conversation = ({
   const [searchParams, setSearchParams] = useSearchParams();
 
   const initialQuery = searchParams.get('query') ?? '';
+  const shouldAutoSend = searchParams.get('autoSend') === 'true';
 
   const [input, setInput] = useState(initialQuery);
   const inputRef = useRef<HTMLInputElement>(null);
   const autoSentRef = useRef(false);
-
-  // Capture autoSend BEFORE cleanup runs
-  const shouldAutoSend = useRef(
-    searchParams.get('autoSend') === 'true',
-  ).current;
-
-  // Clean up URL parameters after capturing
-  useEffect(() => {
-    if (
-      initialQuery &&
-      (searchParams.has('query') || searchParams.has('autoSend'))
-    ) {
-      setSearchParams(
-        params => {
-          params.delete('query');
-          params.delete('autoSend');
-          return params;
-        },
-        { replace: true },
-      );
-    }
-  }, [initialQuery, searchParams, setSearchParams]);
 
   const [modelId, setModelId] = useLocalStorage<string | undefined>(
     'modelId',
@@ -227,9 +206,25 @@ export const Conversation = ({
       !loadingHistory
     ) {
       autoSentRef.current = true;
-      sendMessage();
+      sendMessage().then(() => {
+        setSearchParams(
+          params => {
+            params.delete('query');
+            params.delete('autoSend');
+            return params;
+          },
+          { replace: true },
+        );
+      });
     }
-  }, [initialQuery, shouldAutoSend, modelId, loadingHistory, sendMessage]);
+  }, [
+    initialQuery,
+    shouldAutoSend,
+    modelId,
+    loadingHistory,
+    sendMessage,
+    setSearchParams,
+  ]);
 
   const messageEndRef = useRef<HTMLDivElement>(null);
 

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -47,15 +47,7 @@ export const Conversation = ({
 
   const [input, setInput] = useState(initialQuery);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (initialQuery && searchParams.has('query')) {
-      setSearchParams(params => {
-        params.delete('query');
-        return params;
-      });
-    }
-  }, [initialQuery, searchParams, setSearchParams]);
+  const autoSentRef = useRef(false);
 
   const [modelId, setModelId] = useLocalStorage<string | undefined>(
     'modelId',
@@ -201,7 +193,21 @@ export const Conversation = ({
     errorApi,
     setInput,
     toolsEnabled,
+    analytics,
+    additionalSystemMessages,
   ]);
+
+  // Auto-send initial query
+  useEffect(() => {
+    if (initialQuery && !autoSentRef.current && modelId && !loadingHistory) {
+      autoSentRef.current = true;
+      sendMessage();
+      setSearchParams(params => {
+        params.delete('query');
+        return params;
+      });
+    }
+  }, [initialQuery, modelId, loadingHistory, sendMessage, setSearchParams]);
 
   const messageEndRef = useRef<HTMLDivElement>(null);
 

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -64,7 +64,6 @@ export const Conversation = ({
       }, 100);
       return () => clearTimeout(timer);
     }
-    return undefined;
   }, [initialQuery, searchParams, setSearchParams]);
 
   const [modelId, setModelId] = useLocalStorage<string | undefined>(

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -49,17 +49,25 @@ export const Conversation = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const autoSentRef = useRef(false);
 
-  // Clean up URL parameters after pre-populating (always, not just on auto-send)
+  // Capture autoSend BEFORE cleanup runs
+  const shouldAutoSend = useRef(
+    searchParams.get('autoSend') === 'true',
+  ).current;
+
+  // Clean up URL parameters after capturing
   useEffect(() => {
     if (
       initialQuery &&
       (searchParams.has('query') || searchParams.has('autoSend'))
     ) {
-      setSearchParams(params => {
-        params.delete('query');
-        params.delete('autoSend');
-        return params;
-      });
+      setSearchParams(
+        params => {
+          params.delete('query');
+          params.delete('autoSend');
+          return params;
+        },
+        { replace: true },
+      );
     }
   }, [initialQuery, searchParams, setSearchParams]);
 
@@ -209,13 +217,11 @@ export const Conversation = ({
     toolsEnabled,
   ]);
 
-  // Auto-send only when autoSend=true parameter is present
+  // Auto-send only when autoSend=true parameter was present
   useEffect(() => {
-    const autoSend = searchParams.get('autoSend') === 'true';
-
     if (
       initialQuery &&
-      autoSend &&
+      shouldAutoSend &&
       !autoSentRef.current &&
       modelId &&
       !loadingHistory
@@ -223,7 +229,7 @@ export const Conversation = ({
       autoSentRef.current = true;
       sendMessage();
     }
-  }, [initialQuery, modelId, loadingHistory, sendMessage, searchParams]);
+  }, [initialQuery, shouldAutoSend, modelId, loadingHistory, sendMessage]);
 
   const messageEndRef = useRef<HTMLDivElement>(null);
 

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -55,14 +55,11 @@ export const Conversation = ({
       initialQuery &&
       (searchParams.has('query') || searchParams.has('autoSend'))
     ) {
-      const timer = setTimeout(() => {
-        setSearchParams(params => {
-          params.delete('query');
-          params.delete('autoSend');
-          return params;
-        });
-      }, 100);
-      return () => clearTimeout(timer);
+      setSearchParams(params => {
+        params.delete('query');
+        params.delete('autoSend');
+        return params;
+      });
     }
   }, [initialQuery, searchParams, setSearchParams]);
 

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -197,9 +197,9 @@ export const Conversation = ({
     additionalSystemMessages,
   ]);
 
-  // CHANGED: Auto-send only when autoSend=true parameter is present
+  // Auto-send only when autoSend=true parameter is present
   useEffect(() => {
-    const autoSend = searchParams.get('autoSend') === 'true'; // ADDED THIS LINE
+    const autoSend = searchParams.get('autoSend') === 'true'; 
 
     if (
       initialQuery &&
@@ -212,7 +212,7 @@ export const Conversation = ({
       sendMessage();
       setSearchParams(params => {
         params.delete('query');
-        params.delete('autoSend'); // ADDED: Also clean up autoSend param
+        params.delete('autoSend'); 
         return params;
       });
     }


### PR DESCRIPTION
### Summary
Adds support for URL query parameters to automatically send messages in the AI Assistant conversation page, enabling users to configure AI Assistant as a **custom search engine in their browser**.

### Solution
Implemented two URL parameters:
 `?query=text ` - Pre-fills the input field (manual send required)
 `?query=text&autoSend=true ` - Pre-fills AND auto-sends the message
Key features:
✅ Safe capture of autoSend parameter before URL cleanup (prevents race condition)
✅ Clean URLs after processing (parameters removed with [replace: true](vscode-file://vscode-app/c:/Users/EbrahiM/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
✅ Single-send guarantee using ref (prevents duplicate sends on re-renders)
✅ Browser back button safe (won't re-trigger auto-send)
