### PR TITLE
fix: update langfuse and langchain analtyics to work after updates

### DIFF
--- a/.changeset/swift-aliens-train.md
+++ b/.changeset/swift-aliens-train.md
@@ -1,0 +1,5 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant': major
+---
+
+fix analytics to work with the updated Langhain (v1) version

--- a/.changeset/swift-aliens-train.md
+++ b/.changeset/swift-aliens-train.md
@@ -2,4 +2,4 @@
 '@sweetoburrito/backstage-plugin-ai-assistant': major
 ---
 
-fix analytics to work with the updated Langhain (v1) version
+fix analytics to work with the updated LangChain (v1) version

--- a/plugins/ai-assistant-backend/src/services/callbacks.ts
+++ b/plugins/ai-assistant-backend/src/services/callbacks.ts
@@ -61,7 +61,7 @@ const createCallbackService =
 
           const callbackData = await chainMetadataCallback(options);
 
-          Object.assign(metadata, callbackData.metadata);
+          Object.assign(metadata, callbackData);
         }
 
         return { metadata };

--- a/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
+++ b/plugins/ai-assistant/src/components/Conversation/Conversation.tsx
@@ -87,8 +87,13 @@ export const Conversation = ({
   );
 
   const [messages, setMessages] = useState<Message[]>([]);
+  const messagesRef = useRef<Message[]>([]);
 
   const { toolsEnabled } = useChatSettings();
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
 
   useEffect(() => {
     if (!history || !history.length) {
@@ -100,18 +105,17 @@ export const Conversation = ({
 
   const handleMessageUpdate = useCallback(
     (newMessages: Required<Message>[]) => {
+      const newAiMessages = newMessages.filter(
+        message =>
+          message.role !== 'human' &&
+          !messagesRef.current.some(m => m.id === message.id),
+      );
+
       setMessages(prev => {
         const updated = [...prev];
 
         newMessages.forEach(message => {
           const index = updated.findIndex(m => m.id === message.id);
-
-          if (index === -1 && message.role !== 'human') {
-            analytics.captureEvent({
-              action: 'message_received',
-              subject: modelId ?? 'none',
-            });
-          }
 
           if (index === -1) {
             updated.push(message);
@@ -121,6 +125,13 @@ export const Conversation = ({
         });
 
         return updated;
+      });
+
+      newAiMessages.forEach(() => {
+        analytics.captureEvent({
+          action: 'message_received',
+          subject: modelId ?? 'none',
+        });
       });
     },
     [setMessages, analytics, modelId],
@@ -201,6 +212,7 @@ export const Conversation = ({
     errorApi,
     setInput,
     toolsEnabled,
+    analytics,
   ]);
 
   const messageEndRef = useRef<HTMLDivElement>(null);

--- a/plugins/ai-assistant/src/hooks/use-analytics.ts
+++ b/plugins/ai-assistant/src/hooks/use-analytics.ts
@@ -1,33 +1,23 @@
-import { analyticsApiRef, useApi } from '@backstage/core-plugin-api';
+import { useAnalytics as useBackstageAnalytics } from '@backstage/core-plugin-api';
+import { useCallback, useMemo } from 'react';
 
 type CaptureEventOptions = {
   action: string;
   subject: string;
   attributes?: Record<string, string | boolean | number>;
-  context?: Record<string, string | boolean | number | undefined>;
 };
 
 export const useAnalytics = () => {
-  const analyticsApi = useApi(analyticsApiRef);
+  const analyticsTracker = useBackstageAnalytics();
 
-  const captureEvent = ({
-    action,
-    subject,
-    attributes = {},
-    context = {},
-  }: CaptureEventOptions) => {
-    analyticsApi.captureEvent({
-      action: `ai_assistant_${action}`,
-      subject,
-      context: {
-        extension: 'ai-assistant',
-        pluginId: 'ai-assistant',
-        routeRef: 'ai-assistant',
-        ...context,
-      },
-      attributes,
-    });
-  };
+  const captureEvent = useCallback(
+    ({ action, subject, attributes }: CaptureEventOptions) => {
+      analyticsTracker.captureEvent(`ai_assistant_${action}`, subject, {
+        attributes,
+      });
+    },
+    [analyticsTracker],
+  );
 
-  return { captureEvent };
+  return useMemo(() => ({ captureEvent }), [captureEvent]);
 };


### PR DESCRIPTION
This pull request introduces a major update to the AI Assistant plugin, focusing on fixing analytics tracking to be compatible with the updated LangChain v1 and refactoring the analytics implementation for better reliability and maintainability. The key changes include updating how analytics events are captured, ensuring accurate event tracking for AI messages, and aligning backend metadata handling with the new LangChain version.

**Analytics improvements and refactoring:**

* Refactored the `use-analytics.ts` hook to use Backstage's `useAnalytics` API directly, simplifying the event capture logic and ensuring analytics events are tracked with the correct context and attributes.
* Updated the `Conversation` component to reliably track received AI messages using a `messagesRef` and improved logic for capturing 'message_received' events, ensuring no duplicate events and more accurate analytics. [[1]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R93-R100) [[2]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R111-L118) [[3]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R132-R138) [[4]](diffhunk://#diff-5f1efaf425d6cdb57e6c9e671d73522cc64f22d9b875efcca3c94c60ec488d06R218)

**Backend compatibility with LangChain v1:**

* Modified the callback service in `callbacks.ts` to assign metadata in a way compatible with LangChain v1, ensuring analytics and metadata tracking work correctly after the upgrade.

**Changelog and release notes:**

* Added a changeset marking this as a major release for `@sweetoburrito/backstage-plugin-ai-assistant`, highlighting the analytics fix for LangChain v1.