### PR TITLE
feat: normalize MCP server names and improve input handling

### DIFF
--- a/.changeset/great-rockets-clean.md
+++ b/.changeset/great-rockets-clean.md
@@ -1,0 +1,6 @@
+---
+'@sweetoburrito/backstage-plugin-ai-assistant-backend': patch
+'@sweetoburrito/backstage-plugin-ai-assistant': patch
+---
+
+Standardizes how MCP server names are handled throughout both the backend service and frontend UI to prevent duplicate and inconsistent entries

--- a/plugins/ai-assistant-backend/src/services/mcp/index.ts
+++ b/plugins/ai-assistant-backend/src/services/mcp/index.ts
@@ -28,6 +28,27 @@ type CreateMcpServiceOptions = {
 
 const MCP_SETTINGS_TYPE = 'mcp_server_config';
 
+const normalizeMcpServerName = (name: string): string => {
+  return name.trim().replace(/[\s-]/g, '_');
+};
+
+const normalizeMcpServerConfigs = (
+  configs: McpServerConfig[],
+): McpServerConfig[] => {
+  const normalizedByName = configs.reduce((acc, server) => {
+    const normalizedName = normalizeMcpServerName(server.name);
+
+    acc[normalizedName] = {
+      ...server,
+      name: normalizedName,
+    };
+
+    return acc;
+  }, {} as Record<string, McpServerConfig>);
+
+  return Object.values(normalizedByName);
+};
+
 export type McpService = {
   getTools: (credentials: BackstageCredentials) => Promise<Tool[]>;
   getUserMcpServerConfigNames: (
@@ -171,18 +192,24 @@ export const createMcpService = async ({
     credentials,
     mcpConfig,
   ) => {
-    const { name } = mcpConfig;
+    const normalizedName = normalizeMcpServerName(mcpConfig.name);
+    const normalizedConfig: McpServerConfig = {
+      ...mcpConfig,
+      name: normalizedName,
+    };
 
-    const existingConfig = await getUserMcpServerConfig(credentials);
+    const existingConfig = normalizeMcpServerConfigs(
+      await getUserMcpServerConfig(credentials),
+    );
 
     const existingServerIndex = existingConfig.findIndex(
-      server => server.name === name,
+      server => server.name === normalizedName,
     );
 
     if (existingServerIndex === -1) {
-      existingConfig.push(mcpConfig);
+      existingConfig.push(normalizedConfig);
     } else {
-      existingConfig[existingServerIndex] = mcpConfig;
+      existingConfig[existingServerIndex] = normalizedConfig;
     }
 
     await validateMcpServerConfig(existingConfig);
@@ -207,10 +234,13 @@ export const createMcpService = async ({
 
   const deleteUserMcpServerConfig: McpService['deleteUserMcpServerConfig'] =
     async (credentials, name) => {
-      const existingConfig = await getUserMcpServerConfig(credentials);
+      const normalizedName = normalizeMcpServerName(name);
+      const existingConfig = normalizeMcpServerConfigs(
+        await getUserMcpServerConfig(credentials),
+      );
 
       const updatedConfig: Record<string, string> = existingConfig
-        .filter(server => server.name !== name)
+        .filter(server => server.name !== normalizedName)
         .reduce((acc, server) => {
           acc[server.name] = encrypt(
             JSON.stringify(server.options),

--- a/plugins/ai-assistant/src/components/SettingsModal/tabs/McpServers/McpServers.tsx
+++ b/plugins/ai-assistant/src/components/SettingsModal/tabs/McpServers/McpServers.tsx
@@ -24,6 +24,15 @@ type McpConfigFormData = {
   options: string;
 };
 
+const normalizeMcpServerName = (name: string): string => {
+  return name.trim().replace(/[\s-]/g, '_');
+};
+
+const filterServerNameInput = (input: string): string => {
+  // Allow only letters, numbers, spaces, and underscores
+  return input.replace(/[^a-zA-Z0-9\s_]/g, '');
+};
+
 export const Tab = () => {
   const mcpApi = useApi(mcpApiRef);
   const alertApi = useApi(alertApiRef);
@@ -73,6 +82,8 @@ export const Tab = () => {
       return false;
     }
 
+    const normalizedName = normalizeMcpServerName(config.name);
+
     try {
       const parsedConfig = JSON.parse(config.options);
 
@@ -90,7 +101,7 @@ export const Tab = () => {
 
     // Check for duplicate names (excluding current editing item)
     const isDuplicate = configs.some(
-      (c, index) => c === config.name.trim() && index !== editingIndex,
+      (c, index) => normalizeMcpServerName(c) === normalizedName && index !== editingIndex,
     );
 
     if (isDuplicate) {
@@ -107,9 +118,10 @@ export const Tab = () => {
 
     try {
       const parsedOptions = JSON.parse(currentConfig.options);
+      const normalizedName = normalizeMcpServerName(currentConfig.name);
 
       const newConfig: McpServerConfig = {
-        name: currentConfig.name.trim(),
+        name: normalizedName,
         options: parsedOptions,
       };
 
@@ -236,12 +248,34 @@ export const Tab = () => {
               onChange={e =>
                 setCurrentConfig({
                   ...currentConfig,
-                  name: e.target.value,
+                  name: filterServerNameInput(e.target.value),
                 })
               }
               placeholder="my-mcp-server"
               required
             />
+
+            {currentConfig.name.trim() && (
+              <Box
+                sx={{
+                  p: 1.5,
+                  backgroundColor: 'action.hover',
+                  borderRadius: 1,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                }}
+              >
+                <Typography variant="caption" color="text.secondary">
+                  Will be saved as:
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ fontFamily: 'monospace', fontWeight: 500 }}
+                >
+                  {normalizeMcpServerName(currentConfig.name)}
+                </Typography>
+              </Box>
+            )}
 
             <Box>
               <Typography variant="subtitle2" gutterBottom>

--- a/plugins/ai-assistant/src/components/SettingsModal/tabs/McpServers/McpServers.tsx
+++ b/plugins/ai-assistant/src/components/SettingsModal/tabs/McpServers/McpServers.tsx
@@ -101,7 +101,8 @@ export const Tab = () => {
 
     // Check for duplicate names (excluding current editing item)
     const isDuplicate = configs.some(
-      (c, index) => normalizeMcpServerName(c) === normalizedName && index !== editingIndex,
+      (c, index) =>
+        normalizeMcpServerName(c) === normalizedName && index !== editingIndex,
     );
 
     if (isDuplicate) {


### PR DESCRIPTION
<img width="1286" height="742" alt="image" src="https://github.com/user-attachments/assets/8c0b5ff7-4bfc-4c81-89a4-4679c48a287f" />

This pull request standardizes how MCP server names are handled throughout both the backend service and frontend UI to prevent duplicate and inconsistent entries. The main changes include normalizing server names (trimming, replacing spaces and hyphens with underscores), validating input, and improving the user interface to show how names will be saved.

**Backend normalization and consistency:**

* Added a `normalizeMcpServerName` function to ensure all MCP server names are trimmed and have spaces/hyphens replaced with underscores, applied throughout backend logic (`index.ts`).
* Updated backend logic to normalize names when adding, updating, or deleting server configs, preventing duplicates and inconsistencies. [[1]](diffhunk://#diff-51b383797a2f1566b646233fb77339ccb9cb734389faa5be6aecc9363fe0682eL174-R212) [[2]](diffhunk://#diff-51b383797a2f1566b646233fb77339ccb9cb734389faa5be6aecc9363fe0682eL210-R243)

**Frontend validation and user experience:**

* Added `normalizeMcpServerName` and `filterServerNameInput` functions on the frontend to ensure consistent naming and restrict input to valid characters.
* Updated duplicate name checks and config creation to use normalized names, ensuring consistency with the backend. [[1]](diffhunk://#diff-4d6252a2416a4f089969dadd025c186132a66d4613bdda3e87805b34c05c05b5R85-R86) [[2]](diffhunk://#diff-4d6252a2416a4f089969dadd025c186132a66d4613bdda3e87805b34c05c05b5L93-R104) [[3]](diffhunk://#diff-4d6252a2416a4f089969dadd025c186132a66d4613bdda3e87805b34c05c05b5R121-R124)
* Enhanced the UI to preview the normalized server name to the user as they type, improving clarity and reducing confusion.